### PR TITLE
chore: CI only runs on app code changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,26 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    paths:
+      - 'WalkableKit/**'
+      - 'WalkableApp/**'
+      - 'WalkableWatch/**'
+      - 'WalkableWidgets/**'
+      - 'WalkableTests/**'
+      - 'WalkableUITests/**'
+      - 'project.yml'
+      - 'Makefile'
+      - '.github/workflows/**'
   push:
     branches: [main]
+    paths:
+      - 'WalkableKit/**'
+      - 'WalkableApp/**'
+      - 'WalkableWatch/**'
+      - 'WalkableWidgets/**'
+      - 'WalkableTests/**'
+      - 'WalkableUITests/**'
+      - 'project.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## What
Add path filters to CI workflow.

## Why
Updating README, docs, or other non-code files shouldn't trigger a full iOS + watchOS build.

## How
Added `paths:` filter to both `pull_request` and `push` triggers. CI only runs when these change:
- `WalkableKit/**`, `WalkableApp/**`, `WalkableWatch/**`, `WalkableWidgets/**`
- `WalkableTests/**`, `WalkableUITests/**`
- `project.yml`, `Makefile`
- `.github/workflows/**`

Ignored: `README.md`, `CONTRIBUTING.md`, `LICENSE`, `docs/`, `assets/`, `.maestro/`