### PR TITLE
chore: remove Makefile and .github from CI path filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ on:
       - 'WalkableTests/**'
       - 'WalkableUITests/**'
       - 'project.yml'
-      - 'Makefile'
-      - '.github/workflows/**'
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
Removes Makefile and .github/workflows from CI triggers. Only app source, tests, and project.yml trigger builds.