### PR TITLE
feat: Settings tab with map style, voice, haptics, units

### DIFF
--- a/Walkable.xcodeproj/project.pbxproj
+++ b/Walkable.xcodeproj/project.pbxproj
@@ -26,11 +26,13 @@
 		54D5A3D95030A148498D293F /* PaceTrendChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB9C7705FA9827427AC0DCB1 /* PaceTrendChart.swift */; };
 		55AB96BC7D959B5C67430B60 /* DrawModeOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6AA5849D96973C9AD6788D2 /* DrawModeOverlay.swift */; };
 		5994E70C1CC052FB526BA8B0 /* RouteListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44DBE628CD2816AF0CC6C0E3 /* RouteListView.swift */; };
+		5A2BF64531334790D7605761 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7E63BD57723A20BFF593454 /* SettingsView.swift */; };
 		5B28C2E1924A20CF706345EE /* WatchRouteListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE0975B78BD16789EBECAD7 /* WatchRouteListViewModel.swift */; };
 		5C960F1C0B0A90FACFC36CB1 /* LibraryUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95EBB6A4E8D743C84A1A3EE4 /* LibraryUITests.swift */; };
 		5F0E584E87636F6B3F0E46E1 /* WaypointArrivalCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2473363F5C159BB97A60F8BE /* WaypointArrivalCard.swift */; };
 		6167C81B7128737C4BD52983 /* ActiveWalkViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E35D80372841BFF77ADE9BA /* ActiveWalkViewModel.swift */; };
 		67E7CC5BE31B58EAE6DB3F9F /* LibraryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785B5C345A8361B05AF07A23 /* LibraryViewModel.swift */; };
+		6822EECB273BD85FCE7BF3BB /* MapStylePreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A652311E9D004C70AA4B541 /* MapStylePreference.swift */; };
 		6C0D38EBBAD1D1E14D3CD667 /* TemplateGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C02D137ACE6ED0D2CF2BC24 /* TemplateGeneratorTests.swift */; };
 		6C894D64C962FB2CE8ADB87B /* PathSimplifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416C78792D66DFAECF79F7AE /* PathSimplifierTests.swift */; };
 		6E0401483C3C5BE0369B6DB4 /* CreateRouteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E901C4614536C17E35B73CB1 /* CreateRouteViewModel.swift */; };
@@ -127,6 +129,7 @@
 
 /* Begin PBXFileReference section */
 		06955A99B18F0995ED28EAA4 /* GlassButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassButton.swift; sourceTree = "<group>"; };
+		0A652311E9D004C70AA4B541 /* MapStylePreference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapStylePreference.swift; sourceTree = "<group>"; };
 		0C02D137ACE6ED0D2CF2BC24 /* TemplateGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateGeneratorTests.swift; sourceTree = "<group>"; };
 		0CC07428EAB927C5ADA70A0E /* PinModeOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinModeOverlay.swift; sourceTree = "<group>"; };
 		151B33648D4EBA203CF68828 /* WalkableUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkableUITests.swift; sourceTree = "<group>"; };
@@ -146,9 +149,9 @@
 		44DBE628CD2816AF0CC6C0E3 /* RouteListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteListView.swift; sourceTree = "<group>"; };
 		4555554BF8D7071BD426467B /* SaveRouteSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveRouteSheet.swift; sourceTree = "<group>"; };
 		4A200AD9B414882AC6C7C572 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		51D80C129C05029BAD7DE958 /* WalkableApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WalkableApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		5515782EF765667BB5836D12 /* WalkableWidgets.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = WalkableWidgets.appex; sourceTree = BUILT_PRODUCTS_DIR; };
-		57B9A25E290E6711909B627B /* WalkableKit */ = {isa = PBXFileReference; lastKnownFileType = folder; path = WalkableKit; sourceTree = SOURCE_ROOT; };
+		51D80C129C05029BAD7DE958 /* WalkableApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = WalkableApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		5515782EF765667BB5836D12 /* WalkableWidgets.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = WalkableWidgets.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		57B9A25E290E6711909B627B /* WalkableKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = WalkableKit; path = WalkableKit; sourceTree = SOURCE_ROOT; };
 		57F061AAADC8839C2E49EE10 /* WalkTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkTabView.swift; sourceTree = "<group>"; };
 		5DB7618EACDEED770EA1628E /* WalkableLiveActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkableLiveActivity.swift; sourceTree = "<group>"; };
 		65910331A837344A3DF7308C /* WalkableWidgetsBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkableWidgetsBundle.swift; sourceTree = "<group>"; };
@@ -178,6 +181,7 @@
 		C6AA5849D96973C9AD6788D2 /* DrawModeOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawModeOverlay.swift; sourceTree = "<group>"; };
 		C8CEF479EC71EEEE1696F797 /* WalkStatsBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkStatsBar.swift; sourceTree = "<group>"; };
 		D59ED20DEE31A8F577687C4B /* StatsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsUITests.swift; sourceTree = "<group>"; };
+		D7E63BD57723A20BFF593454 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		DB9C7705FA9827427AC0DCB1 /* PaceTrendChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaceTrendChart.swift; sourceTree = "<group>"; };
 		DCF6B8E22583E08984B290DD /* WatchSummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchSummaryView.swift; sourceTree = "<group>"; };
 		DD25E2B689A23CD64502A618 /* RouteDetailSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteDetailSheet.swift; sourceTree = "<group>"; };
@@ -326,6 +330,7 @@
 				06955A99B18F0995ED28EAA4 /* GlassButton.swift */,
 				F5E6D32D966038AD56757CC3 /* GlassCard.swift */,
 				B6A51C3C02B3BA119213CAA1 /* Haptics.swift */,
+				0A652311E9D004C70AA4B541 /* MapStylePreference.swift */,
 				ADF1EB7F201E4B7BD61D4985 /* RouteMapOverlay.swift */,
 			);
 			path = Shared;
@@ -355,6 +360,14 @@
 			path = WalkableUITests;
 			sourceTree = "<group>";
 		};
+		8BC3D7FAABDD8FDA890A5205 /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				D7E63BD57723A20BFF593454 /* SettingsView.swift */,
+			);
+			path = Settings;
+			sourceTree = "<group>";
+		};
 		8CE486C7711F9BFF4881D413 /* Packages */ = {
 			isa = PBXGroup;
 			children = (
@@ -381,6 +394,7 @@
 			children = (
 				A874B785337632610AB3CE16 /* Create */,
 				D73FAC2D803CE30B72E6E7E4 /* Library */,
+				8BC3D7FAABDD8FDA890A5205 /* Settings */,
 				496FF750C87457A70096964D /* Shared */,
 				F2CDC80740487C3C1A1931C3 /* Stats */,
 				28290EFED72C6527435F3B71 /* Walk */,
@@ -614,6 +628,7 @@
 				70EAEA4A912BD094E28BE123 /* Haptics.swift in Sources */,
 				99BC7ABFCFBF0765A3F8D7CD /* LibraryView.swift in Sources */,
 				67E7CC5BE31B58EAE6DB3F9F /* LibraryViewModel.swift in Sources */,
+				6822EECB273BD85FCE7BF3BB /* MapStylePreference.swift in Sources */,
 				54D5A3D95030A148498D293F /* PaceTrendChart.swift in Sources */,
 				D4A93ABF11B70E3BE0C210C5 /* PinModeOverlay.swift in Sources */,
 				789071D67D46C4AE7996E31A /* RouteCardView.swift in Sources */,
@@ -622,6 +637,7 @@
 				2270E1523F109D5066BF7B53 /* RouteMapOverlay.swift in Sources */,
 				8E28EA1F1188392F072F34B7 /* SaveRouteSheet.swift in Sources */,
 				D88854C8D9E184DF6130F5BC /* SessionDetailSheet.swift in Sources */,
+				5A2BF64531334790D7605761 /* SettingsView.swift in Sources */,
 				544A9359D87948DFFF580080 /* StatCardView.swift in Sources */,
 				EF4F3E21943AF22940BB8D7C /* StatsView.swift in Sources */,
 				011791246714E964BB8E66C0 /* StatsViewModel.swift in Sources */,
@@ -716,7 +732,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = WalkableWatch/WalkableWatch.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = HYM2LV4SPQ;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Walkable;
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Walkable reads health data during walks.";
@@ -735,7 +750,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = HYM2LV4SPQ;
 				INFOPLIST_FILE = WalkableWidgets/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Walkable;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -790,7 +804,6 @@
 				CODE_SIGN_ENTITLEMENTS = WalkableApp/WalkableApp.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = HYM2LV4SPQ;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Walkable;
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Walkable reads your health data to show fitness stats.";
@@ -817,7 +830,6 @@
 				CODE_SIGN_ENTITLEMENTS = WalkableApp/WalkableApp.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = HYM2LV4SPQ;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Walkable;
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Walkable reads your health data to show fitness stats.";
@@ -841,7 +853,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = HYM2LV4SPQ;
 				INFOPLIST_FILE = WalkableWidgets/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Walkable;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -917,7 +928,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = WalkableWatch/WalkableWatch.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = HYM2LV4SPQ;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Walkable;
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Walkable reads health data during walks.";

--- a/WalkableApp/Views/Create/CreateRouteView.swift
+++ b/WalkableApp/Views/Create/CreateRouteView.swift
@@ -9,6 +9,7 @@ struct CreateRouteView: View {
     @State private var drawCanvasId = UUID()
     @State private var drawingPoints: [CGPoint] = []
     @State private var mapHeading: Double = 0
+    @AppStorage("mapStyle") private var mapStylePref = "standard"
     @Environment(\.modelContext) private var modelContext
 
     var body: some View {
@@ -157,7 +158,7 @@ struct CreateRouteView: View {
                 // Keep user location dot visible when camera moves
                 UserAnnotation()
             }
-            .mapStyle(.standard(elevation: .realistic))
+            .mapStyle(mapStylePref.asMapStyle)
             .mapControls {
                 MapCompass()
                     .mapControlVisibility(.automatic)

--- a/WalkableApp/Views/Settings/SettingsView.swift
+++ b/WalkableApp/Views/Settings/SettingsView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+import WalkableKit
+
+struct SettingsView: View {
+    @AppStorage("mapStyle") private var mapStyle = "standard"
+    @AppStorage("voiceEnabled") private var voiceEnabled = true
+    @AppStorage("hapticsEnabled") private var hapticsEnabled = true
+    @AppStorage("useMetric") private var useMetric = true
+
+    var body: some View {
+        Form {
+            Section("Map") {
+                Picker("Style", selection: $mapStyle) {
+                    Text("Standard").tag("standard")
+                    Text("Satellite").tag("satellite")
+                    Text("Hybrid").tag("hybrid")
+                }
+            }
+
+            Section("During Walks") {
+                Toggle("Voice Announcements", isOn: $voiceEnabled)
+                Toggle("Haptic Feedback", isOn: $hapticsEnabled)
+            }
+
+            Section("Units") {
+                Picker("Distance", selection: $useMetric) {
+                    Text("Kilometers").tag(true)
+                    Text("Miles").tag(false)
+                }
+                .pickerStyle(.segmented)
+            }
+
+            Section("About") {
+                LabeledContent("Version", value: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0")
+                Link("GitHub Repository", destination: URL(string: "https://github.com/samoht9277/walkable")!)
+                LabeledContent("License", value: "GPLv3")
+            }
+        }
+        .navigationTitle("Settings")
+        .onChange(of: voiceEnabled) { VoiceService.shared.isEnabled = voiceEnabled }
+        .onChange(of: hapticsEnabled) { Haptics.isEnabled = hapticsEnabled }
+        .onAppear {
+            VoiceService.shared.isEnabled = voiceEnabled
+            Haptics.isEnabled = hapticsEnabled
+        }
+    }
+}

--- a/WalkableApp/Views/Shared/Haptics.swift
+++ b/WalkableApp/Views/Shared/Haptics.swift
@@ -1,19 +1,26 @@
 import UIKit
 
 enum Haptics {
+    static var isEnabled = true
+
     static func light() {
+        guard isEnabled else { return }
         UIImpactFeedbackGenerator(style: .light).impactOccurred()
     }
     static func medium() {
+        guard isEnabled else { return }
         UIImpactFeedbackGenerator(style: .medium).impactOccurred()
     }
     static func heavy() {
+        guard isEnabled else { return }
         UIImpactFeedbackGenerator(style: .rigid).impactOccurred()
     }
     static func success() {
+        guard isEnabled else { return }
         UINotificationFeedbackGenerator().notificationOccurred(.success)
     }
     static func error() {
+        guard isEnabled else { return }
         UINotificationFeedbackGenerator().notificationOccurred(.error)
     }
 }

--- a/WalkableApp/Views/Shared/MapStylePreference.swift
+++ b/WalkableApp/Views/Shared/MapStylePreference.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+@preconcurrency import MapKit
+
+extension String {
+    var asMapStyle: MapStyle {
+        switch self {
+        case "satellite": return .imagery
+        case "hybrid": return .hybrid
+        default: return .standard(elevation: .realistic)
+        }
+    }
+
+    var asMapStyleExcludingPOI: MapStyle {
+        switch self {
+        case "satellite": return .imagery
+        case "hybrid": return .hybrid(pointsOfInterest: .excludingAll)
+        default: return .standard(elevation: .realistic, pointsOfInterest: .excludingAll)
+        }
+    }
+}

--- a/WalkableApp/Views/Shared/RouteMapOverlay.swift
+++ b/WalkableApp/Views/Shared/RouteMapOverlay.swift
@@ -7,6 +7,7 @@ struct RouteMapOverlay: View {
     var walkedDistance: Double? = nil
     var currentLocation: CLLocationCoordinate2D? = nil
     var nextWaypointIndex: Int? = nil
+    @AppStorage("mapStyle") private var mapStylePref = "standard"
 
     var body: some View {
         Map {
@@ -44,7 +45,7 @@ struct RouteMapOverlay: View {
                 }
             }
         }
-        .mapStyle(.standard(elevation: .realistic, pointsOfInterest: .excludingAll))
+        .mapStyle(mapStylePref.asMapStyleExcludingPOI)
     }
 
     @ViewBuilder

--- a/WalkableApp/Views/Stats/AllSessionsView.swift
+++ b/WalkableApp/Views/Stats/AllSessionsView.swift
@@ -73,7 +73,7 @@ struct AllSessionsView: View {
             }
             Spacer()
             VStack(alignment: .trailing, spacing: 4) {
-                Text(String(format: "%.2f km", session.totalDistance / 1000))
+                Text(session.totalDistance.formattedDistance)
                     .font(.subheadline.monospacedDigit())
                 HStack(spacing: 12) {
                     Text(session.totalDuration.formattedDuration)

--- a/WalkableApp/Views/Stats/SessionDetailSheet.swift
+++ b/WalkableApp/Views/Stats/SessionDetailSheet.swift
@@ -5,6 +5,7 @@ import WalkableKit
 struct SessionDetailSheet: View {
     let session: WalkSession
     @Environment(\.dismiss) private var dismiss
+    @AppStorage("mapStyle") private var mapStylePref = "standard"
 
     var body: some View {
         NavigationStack {
@@ -49,7 +50,7 @@ struct SessionDetailSheet: View {
                     LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 12) {
                         StatCardView(
                             title: "Distance",
-                            value: String(format: "%.2f km", session.totalDistance / 1000),
+                            value: session.totalDistance.formattedDistance,
                             icon: "ruler",
                             color: .blue
                         )
@@ -133,6 +134,6 @@ struct SessionDetailSheet: View {
                     .stroke(.green, lineWidth: 4)
             }
         }
-        .mapStyle(.standard(elevation: .realistic, pointsOfInterest: .excludingAll))
+        .mapStyle(mapStylePref.asMapStyleExcludingPOI)
     }
 }

--- a/WalkableApp/Views/Stats/StatsView.swift
+++ b/WalkableApp/Views/Stats/StatsView.swift
@@ -41,7 +41,7 @@ struct StatsView: View {
                     LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 12) {
                         StatCardView(
                             title: "Total Distance",
-                            value: String(format: "%.1f km", viewModel.totalDistance / 1000),
+                            value: viewModel.totalDistance.formattedDistance,
                             icon: "ruler",
                             color: .blue
                         )
@@ -81,6 +81,15 @@ struct StatsView: View {
                 .padding(.vertical)
             }
             .navigationTitle("Stats")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    NavigationLink {
+                        SettingsView()
+                    } label: {
+                        Image(systemName: "gearshape")
+                    }
+                }
+            }
             .task { await viewModel.loadStats(sessions: sessions) }
             .onChange(of: viewModel.period) {
                 Task { await viewModel.loadStats(sessions: sessions) }
@@ -162,7 +171,7 @@ struct StatsView: View {
             }
             Spacer()
             VStack(alignment: .trailing, spacing: 4) {
-                Text(String(format: "%.2f km", session.totalDistance / 1000))
+                Text(session.totalDistance.formattedDistance)
                     .font(.subheadline.monospacedDigit())
                 HStack(spacing: 12) {
                     Text(session.totalDuration.formattedDuration)

--- a/WalkableApp/Views/Walk/WalkSummaryView.swift
+++ b/WalkableApp/Views/Walk/WalkSummaryView.swift
@@ -19,7 +19,7 @@ struct WalkSummaryView: View {
                     .font(.title.weight(.bold))
 
                 LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 16) {
-                    summaryCard("Distance", value: String(format: "%.2f km", distance / 1000), icon: "ruler")
+                    summaryCard("Distance", value: distance.formattedDistance, icon: "ruler")
                     summaryCard("Duration", value: duration.formattedDuration, icon: "clock")
                     summaryCard("Avg Pace", value: pace.formattedPace, icon: "speedometer")
                     summaryCard("Calories", value: String(format: "%.0f kcal", calories), icon: "flame")

--- a/WalkableKit/Sources/WalkableKit/Extensions/FormatUtils.swift
+++ b/WalkableKit/Sources/WalkableKit/Extensions/FormatUtils.swift
@@ -1,27 +1,45 @@
 import Foundation
 import CoreLocation
 
+private var _useMetric: Bool {
+    // Default to true (metric) when key has never been set
+    if UserDefaults.standard.object(forKey: "useMetric") == nil { return true }
+    return UserDefaults.standard.bool(forKey: "useMetric")
+}
+
 public extension Double {
-    /// Formats pace (sec/km) as "M:SS /km". Returns "--:--" for invalid values.
+    /// Formats pace (sec/km or sec/mi) as "M:SS /km" or "M:SS /mi". Returns "--:--" for invalid values.
     var formattedPace: String {
         guard self > 0 && self < 3600 else { return "--:--" }
-        let mins = Int(self) / 60
-        let secs = Int(self) % 60
-        return String(format: "%d:%02d /km", mins, secs)
+        let paceValue = _useMetric ? self : self * 1.60934
+        let mins = Int(paceValue) / 60
+        let secs = Int(paceValue) % 60
+        let unit = _useMetric ? "/km" : "/mi"
+        return String(format: "%d:%02d %@", mins, secs, unit)
     }
 
-    /// Formats pace without /km suffix (for compact displays).
+    /// Formats pace without unit suffix (for compact displays).
     var formattedPaceShort: String {
         guard self > 0 && self < 3600 else { return "--:--" }
-        let mins = Int(self) / 60
-        let secs = Int(self) % 60
+        let paceValue = _useMetric ? self : self * 1.60934
+        let mins = Int(paceValue) / 60
+        let secs = Int(paceValue) % 60
         return String(format: "%d:%02d", mins, secs)
     }
 
-    /// Formats meters as "Xm" or "X.Xkm".
+    /// Formats meters as "Xm"/"X.Xkm" or "Xft"/"X.Xmi".
     var formattedDistance: String {
-        if self < 1000 { return String(format: "%.0fm", self) }
-        return String(format: "%.1fkm", self / 1000)
+        if _useMetric {
+            if self < 1000 { return String(format: "%.0fm", self) }
+            return String(format: "%.1fkm", self / 1000)
+        } else {
+            let miles = self / 1609.34
+            if miles < 0.1 {
+                let feet = self * 3.28084
+                return String(format: "%.0fft", feet)
+            }
+            return String(format: "%.1fmi", miles)
+        }
     }
 }
 

--- a/WalkableKit/Sources/WalkableKit/Models/LegSplit.swift
+++ b/WalkableKit/Sources/WalkableKit/Models/LegSplit.swift
@@ -29,9 +29,6 @@ public final class LegSplit {
     }
 
     public var formattedPace: String {
-        guard pace > 0 else { return "--:--" }
-        let minutes = Int(pace) / 60
-        let seconds = Int(pace) % 60
-        return String(format: "%d:%02d /km", minutes, seconds)
+        pace.formattedPace
     }
 }

--- a/WalkableKit/Sources/WalkableKit/Models/WalkSession.swift
+++ b/WalkableKit/Sources/WalkableKit/Models/WalkSession.swift
@@ -39,9 +39,6 @@ public final class WalkSession {
     }
 
     public var formattedPace: String {
-        guard avgPace > 0 else { return "--:--" }
-        let minutes = Int(avgPace) / 60
-        let seconds = Int(avgPace) % 60
-        return String(format: "%d:%02d /km", minutes, seconds)
+        avgPace.formattedPace
     }
 }


### PR DESCRIPTION
## What
Settings view accessible via gear icon in the Stats tab toolbar.

## Settings
- **Map Style**: Standard / Satellite / Hybrid — applies to all Map views
- **Voice Announcements**: Toggle on/off (wired to VoiceService)
- **Haptic Feedback**: Toggle on/off (wired to Haptics)
- **Units**: Kilometers / Miles — all formatters respect this preference
- **About**: Version, GitHub link, license

## How
- All preferences stored in `@AppStorage` (UserDefaults)
- `FormatUtils.swift` reads `useMetric` preference for distance/pace formatting
- `MapStylePreference.swift` converts stored string to `MapStyle`
- `Haptics.swift` checks `isEnabled` flag before firing
- Map style applied via `@AppStorage("mapStyle")` in each view

## Testing
- [x] Builds on iOS
- [x] Unit tests pass (48/48)
- [x] Map style changes reflected across all views
- [x] Voice/haptics toggles work
- [x] km/mi switch updates all formatters

Closes #10