### PR TITLE
feat: GPX import/export for routes and walk sessions

### DIFF
--- a/Walkable.xcodeproj/project.pbxproj
+++ b/Walkable.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		9B71571B0C080603A2CF3097 /* WalkableKit in Frameworks */ = {isa = PBXBuildFile; productRef = 64DAB2236C6F897B31E25AAD /* WalkableKit */; };
 		A039DE54EC3CF6A5646C55A7 /* WalkableWidgetsBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65910331A837344A3DF7308C /* WalkableWidgetsBundle.swift */; };
 		A547BBF79642102F9C408EC3 /* RouteDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD25E2B689A23CD64502A618 /* RouteDetailSheet.swift */; };
+		A78FD7D07368940E740865B6 /* GPXServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB349395ABCD722A2D201C69 /* GPXServiceTests.swift */; };
 		B854C09C21F548C1E1FCEE2F /* WalkableUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 151B33648D4EBA203CF68828 /* WalkableUITests.swift */; };
 		C8BB583820C6BC7EAC3CA291 /* DrawingCanvas.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1358DBC5A6ABF9406C09C11 /* DrawingCanvas.swift */; };
 		D4A93ABF11B70E3BE0C210C5 /* PinModeOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CC07428EAB927C5ADA70A0E /* PinModeOverlay.swift */; };
@@ -56,6 +57,7 @@
 		D616989BE078C5766CF63C77 /* GlassCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E6D32D966038AD56757CC3 /* GlassCard.swift */; };
 		D88854C8D9E184DF6130F5BC /* SessionDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4396FA147406FD118CC8FB34 /* SessionDetailSheet.swift */; };
 		DFD4AD43C721552B55887680 /* CompassView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B44C75758EF0C7AC84CE39E7 /* CompassView.swift */; };
+		E086D9084CED6FEAD8BA6007 /* GPXFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08131679F170C969DC955433 /* GPXFile.swift */; };
 		E18CA83E688E65632699C5F5 /* NowPlayingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8EDD0A140E15FF36623E578 /* NowPlayingView.swift */; };
 		EAD4E9C3BF1A7C008548127C /* AllSessionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6CB550C19F915950640DF4 /* AllSessionsView.swift */; };
 		ED7C3597B9433D441B5FF1B8 /* WalkStatsBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8CEF479EC71EEEE1696F797 /* WalkStatsBar.swift */; };
@@ -129,6 +131,7 @@
 
 /* Begin PBXFileReference section */
 		06955A99B18F0995ED28EAA4 /* GlassButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassButton.swift; sourceTree = "<group>"; };
+		08131679F170C969DC955433 /* GPXFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPXFile.swift; sourceTree = "<group>"; };
 		0A652311E9D004C70AA4B541 /* MapStylePreference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapStylePreference.swift; sourceTree = "<group>"; };
 		0C02D137ACE6ED0D2CF2BC24 /* TemplateGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateGeneratorTests.swift; sourceTree = "<group>"; };
 		0CC07428EAB927C5ADA70A0E /* PinModeOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinModeOverlay.swift; sourceTree = "<group>"; };
@@ -192,6 +195,7 @@
 		E9D00E57C3DC5BC436ED09A3 /* WatchMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchMapView.swift; sourceTree = "<group>"; };
 		F19610F12212010842919D16 /* WalkSummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkSummaryView.swift; sourceTree = "<group>"; };
 		F5E6D32D966038AD56757CC3 /* GlassCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassCard.swift; sourceTree = "<group>"; };
+		FB349395ABCD722A2D201C69 /* GPXServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPXServiceTests.swift; sourceTree = "<group>"; };
 		FE89E09A4281BDD8AACC4159 /* TemplateModeOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateModeOverlay.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -329,6 +333,7 @@
 			children = (
 				06955A99B18F0995ED28EAA4 /* GlassButton.swift */,
 				F5E6D32D966038AD56757CC3 /* GlassCard.swift */,
+				08131679F170C969DC955433 /* GPXFile.swift */,
 				B6A51C3C02B3BA119213CAA1 /* Haptics.swift */,
 				0A652311E9D004C70AA4B541 /* MapStylePreference.swift */,
 				ADF1EB7F201E4B7BD61D4985 /* RouteMapOverlay.swift */,
@@ -340,6 +345,7 @@
 			isa = PBXGroup;
 			children = (
 				A9A5ABBA0A32C3DE84D9F5BE /* FormatUtilsTests.swift */,
+				FB349395ABCD722A2D201C69 /* GPXServiceTests.swift */,
 				AB45A54BE7D39650928B01EC /* ModelTests.swift */,
 				416C78792D66DFAECF79F7AE /* PathSimplifierTests.swift */,
 				6765B12731821E706EA6FBEC /* PolylineSplitterTests.swift */,
@@ -623,6 +629,7 @@
 				6E0401483C3C5BE0369B6DB4 /* CreateRouteViewModel.swift in Sources */,
 				55AB96BC7D959B5C67430B60 /* DrawModeOverlay.swift in Sources */,
 				C8BB583820C6BC7EAC3CA291 /* DrawingCanvas.swift in Sources */,
+				E086D9084CED6FEAD8BA6007 /* GPXFile.swift in Sources */,
 				52DBB50296540319AFE3ABE6 /* GlassButton.swift in Sources */,
 				D616989BE078C5766CF63C77 /* GlassCard.swift in Sources */,
 				70EAEA4A912BD094E28BE123 /* Haptics.swift in Sources */,
@@ -681,6 +688,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				354F616FC4FAD1FDE8A1023B /* FormatUtilsTests.swift in Sources */,
+				A78FD7D07368940E740865B6 /* GPXServiceTests.swift in Sources */,
 				FBE036444564236017088B6A /* ModelTests.swift in Sources */,
 				6C894D64C962FB2CE8ADB87B /* PathSimplifierTests.swift in Sources */,
 				0839B8E7B7EC64506E62D166 /* PolylineSplitterTests.swift in Sources */,

--- a/Walkable.xcodeproj/xcshareddata/xcschemes/WalkableWatch.xcscheme
+++ b/Walkable.xcodeproj/xcshareddata/xcschemes/WalkableWatch.xcscheme
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1600"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -26,7 +27,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/WalkableApp/Views/Library/LibraryView.swift
+++ b/WalkableApp/Views/Library/LibraryView.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 import SwiftData
+import UniformTypeIdentifiers
+import CoreLocation
 import WalkableKit
 
 struct LibraryView: View {
@@ -7,6 +9,9 @@ struct LibraryView: View {
     @Environment(\.modelContext) private var modelContext
     @State private var viewModel = LibraryViewModel()
     @ObservedObject private var locationService = LocationService.shared
+    @State private var showImportPicker = false
+    @State private var importError: String?
+    @State private var showImportError = false
 
     // Callback when user starts a walk from library
     var onStartWalk: ((Route) -> Void)?
@@ -89,6 +94,24 @@ struct LibraryView: View {
                         Label("Sort", systemImage: "arrow.up.arrow.down")
                     }
                 }
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        showImportPicker = true
+                    } label: {
+                        Image(systemName: "square.and.arrow.down")
+                    }
+                }
+            }
+            .fileImporter(
+                isPresented: $showImportPicker,
+                allowedContentTypes: [.xml, UTType(filenameExtension: "gpx") ?? .xml]
+            ) { result in
+                handleImport(result)
+            }
+            .alert("Import Failed", isPresented: $showImportError) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(importError ?? "Could not read GPX file.")
             }
             .sheet(item: $viewModel.selectedRoute) { route in
                 RouteDetailSheet(route: route) {
@@ -97,6 +120,60 @@ struct LibraryView: View {
                 .presentationDetents([.large])
             }
         }
+    }
+
+    private func handleImport(_ result: Result<URL, Error>) {
+        guard case .success(let url) = result else {
+            importError = "Could not access the file."
+            showImportError = true
+            return
+        }
+        guard url.startAccessingSecurityScopedResource() else {
+            importError = "Permission denied."
+            showImportError = true
+            return
+        }
+        defer { url.stopAccessingSecurityScopedResource() }
+
+        guard let gpxString = try? String(contentsOf: url, encoding: .utf8),
+              let gpxData = GPXService.parse(gpxString: gpxString) else {
+            importError = "Invalid or unreadable GPX file."
+            showImportError = true
+            return
+        }
+
+        let route = Route(name: gpxData.name ?? url.deletingPathExtension().lastPathComponent)
+
+        for (index, wp) in gpxData.waypoints.enumerated() {
+            let waypoint = Waypoint(index: index, latitude: wp.latitude, longitude: wp.longitude, label: wp.name)
+            route.waypoints.append(waypoint)
+        }
+
+        if !gpxData.trackPoints.isEmpty {
+            let coords = gpxData.trackPoints.map { CodableCoordinate(latitude: $0.latitude, longitude: $0.longitude) }
+            route.polylineData = try? JSONEncoder().encode(coords)
+
+            var totalDistance = 0.0
+            for i in 1..<gpxData.trackPoints.count {
+                let a = CLLocation(latitude: gpxData.trackPoints[i - 1].latitude, longitude: gpxData.trackPoints[i - 1].longitude)
+                let b = CLLocation(latitude: gpxData.trackPoints[i].latitude, longitude: gpxData.trackPoints[i].longitude)
+                totalDistance += a.distance(from: b)
+            }
+            route.distance = totalDistance
+        }
+
+        let allLats = gpxData.waypoints.map(\.latitude) + gpxData.trackPoints.map(\.latitude)
+        let allLons = gpxData.waypoints.map(\.longitude) + gpxData.trackPoints.map(\.longitude)
+        if let minLat = allLats.min(), let maxLat = allLats.max(),
+           let minLon = allLons.min(), let maxLon = allLons.max() {
+            route.centerLatitude = (minLat + maxLat) / 2
+            route.centerLongitude = (minLon + maxLon) / 2
+        }
+
+        modelContext.insert(route)
+        try? modelContext.save()
+        Haptics.success()
+        SyncService.shared.syncRoute(route, operation: .create)
     }
 
     private func tagChip(_ title: String, isSelected: Bool, action: @escaping () -> Void) -> some View {

--- a/WalkableApp/Views/Library/RouteDetailSheet.swift
+++ b/WalkableApp/Views/Library/RouteDetailSheet.swift
@@ -86,8 +86,18 @@ struct RouteDetailSheet: View {
                     }
                 }
                 ToolbarItem(placement: .primaryAction) {
-                    Button { showEditSheet = true } label: {
-                        Image(systemName: "pencil")
+                    Menu {
+                        Button { showEditSheet = true } label: {
+                            Label("Edit", systemImage: "pencil")
+                        }
+                        ShareLink(
+                            item: exportGPX(),
+                            preview: SharePreview(route.name, image: Image(systemName: "map"))
+                        ) {
+                            Label("Export GPX", systemImage: "square.and.arrow.up")
+                        }
+                    } label: {
+                        Image(systemName: "ellipsis.circle")
                     }
                 }
             }
@@ -96,6 +106,14 @@ struct RouteDetailSheet: View {
                     .presentationDetents([.medium])
             }
         }
+    }
+
+    private func exportGPX() -> GPXFile {
+        let gpxString = GPXService.export(route: route)
+        let safeName = route.name.replacingOccurrences(of: "/", with: "-")
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("\(safeName).gpx")
+        try? gpxString.write(to: url, atomically: true, encoding: .utf8)
+        return GPXFile(url: url)
     }
 }
 

--- a/WalkableApp/Views/Shared/GPXFile.swift
+++ b/WalkableApp/Views/Shared/GPXFile.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct GPXFile: Transferable {
+    let url: URL
+
+    static var transferRepresentation: some TransferRepresentation {
+        FileRepresentation(exportedContentType: .xml) { file in
+            SentTransferredFile(file.url)
+        }
+    }
+}

--- a/WalkableApp/Views/Stats/SessionDetailSheet.swift
+++ b/WalkableApp/Views/Stats/SessionDetailSheet.swift
@@ -117,8 +117,28 @@ struct SessionDetailSheet: View {
                             .foregroundStyle(.secondary)
                     }
                 }
+                ToolbarItem(placement: .primaryAction) {
+                    if session.gpsTrackData != nil {
+                        ShareLink(
+                            item: exportSessionGPX(),
+                            preview: SharePreview(session.route?.name ?? "Walk", image: Image(systemName: "figure.walk"))
+                        ) {
+                            Image(systemName: "square.and.arrow.up")
+                        }
+                    }
+                }
             }
         }
+    }
+
+    private func exportSessionGPX() -> GPXFile {
+        let gpxString = GPXService.exportSession(session: session, route: session.route)
+        let name = session.route?.name ?? "Walk"
+        let safeName = name.replacingOccurrences(of: "/", with: "-")
+        let dateStr = session.startedAt.formatted(.dateTime.year().month().day())
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("\(safeName) \(dateStr).gpx")
+        try? gpxString.write(to: url, atomically: true, encoding: .utf8)
+        return GPXFile(url: url)
     }
 
     @ViewBuilder

--- a/WalkableKit/Sources/WalkableKit/Services/GPXService.swift
+++ b/WalkableKit/Sources/WalkableKit/Services/GPXService.swift
@@ -1,0 +1,235 @@
+import Foundation
+import CoreLocation
+
+public enum GPXService {
+
+    // MARK: - Export
+
+    /// Export a Route to GPX XML string
+    public static func export(route: Route) -> String {
+        let isoFormatter = ISO8601DateFormatter()
+        var gpx = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <gpx version="1.1" creator="Walkable"
+             xmlns="http://www.topografix.com/GPX/1/1">
+          <metadata>
+            <name>\(escapeXML(route.name))</name>
+            <time>\(isoFormatter.string(from: route.createdAt))</time>
+          </metadata>
+          <rte>
+            <name>\(escapeXML(route.name))</name>
+        """
+
+        for wp in route.sortedWaypoints {
+            gpx += """
+
+                <rtept lat="\(wp.latitude)" lon="\(wp.longitude)">
+                  <name>\(escapeXML(wp.label ?? "Waypoint \(wp.index + 1)"))</name>
+                </rtept>
+            """
+        }
+
+        gpx += "\n  </rte>"
+
+        if let coords = route.decodedPolylineCoordinates {
+            gpx += """
+
+              <trk>
+                <name>\(escapeXML(route.name)) Path</name>
+                <trkseg>
+            """
+            for coord in coords {
+                gpx += """
+
+                  <trkpt lat="\(coord.latitude)" lon="\(coord.longitude)">
+                  </trkpt>
+                """
+            }
+            gpx += """
+
+                </trkseg>
+              </trk>
+            """
+        }
+
+        gpx += "\n</gpx>"
+        return gpx
+    }
+
+    /// Export a WalkSession (with GPS track) to GPX
+    public static func exportSession(session: WalkSession, route: Route?) -> String {
+        let isoFormatter = ISO8601DateFormatter()
+        var gpx = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <gpx version="1.1" creator="Walkable"
+             xmlns="http://www.topografix.com/GPX/1/1">
+          <metadata>
+            <name>\(escapeXML(route?.name ?? "Walk"))</name>
+            <time>\(isoFormatter.string(from: session.startedAt))</time>
+          </metadata>
+        """
+
+        if let route {
+            gpx += "\n  <rte>\n    <name>\(escapeXML(route.name))</name>"
+            for wp in route.sortedWaypoints {
+                gpx += """
+
+                    <rtept lat="\(wp.latitude)" lon="\(wp.longitude)">
+                      <name>\(escapeXML(wp.label ?? "Waypoint \(wp.index + 1)"))</name>
+                    </rtept>
+                """
+            }
+            gpx += "\n  </rte>"
+        }
+
+        if let gpsData = session.gpsTrackData,
+           let coords = gpsData.decodedCoordinates() {
+            gpx += """
+
+              <trk>
+                <name>GPS Track</name>
+                <trkseg>
+            """
+            let duration = session.totalDuration
+            for (i, coord) in coords.enumerated() {
+                let t = duration > 0 ? (Double(i) / Double(max(coords.count - 1, 1))) * duration : 0
+                let time = session.startedAt.addingTimeInterval(t)
+                gpx += """
+
+                  <trkpt lat="\(coord.latitude)" lon="\(coord.longitude)">
+                    <time>\(isoFormatter.string(from: time))</time>
+                  </trkpt>
+                """
+            }
+            gpx += """
+
+                </trkseg>
+              </trk>
+            """
+        }
+
+        gpx += "\n</gpx>"
+        return gpx
+    }
+
+    // MARK: - Import
+
+    /// Parse a GPX file and return waypoints and track points
+    public static func parse(gpxString: String) -> GPXData? {
+        let parser = GPXParser(xmlString: gpxString)
+        return parser.parse()
+    }
+
+    private static func escapeXML(_ string: String) -> String {
+        string
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+    }
+}
+
+// MARK: - GPX Data Types
+
+public struct GPXData {
+    public let name: String?
+    public let waypoints: [GPXWaypoint]
+    public let trackPoints: [GPXTrackPoint]
+}
+
+public struct GPXWaypoint {
+    public let latitude: Double
+    public let longitude: Double
+    public let name: String?
+}
+
+public struct GPXTrackPoint {
+    public let latitude: Double
+    public let longitude: Double
+    public let elevation: Double?
+    public let time: Date?
+}
+
+// MARK: - GPX Parser
+
+class GPXParser: NSObject, XMLParserDelegate {
+    private let xmlString: String
+    private var name: String?
+    private var waypoints: [GPXWaypoint] = []
+    private var trackPoints: [GPXTrackPoint] = []
+
+    private var currentElement = ""
+    private var currentText = ""
+    private var currentLat: Double?
+    private var currentLon: Double?
+    private var currentElevation: Double?
+    private var currentTime: Date?
+    private var currentName: String?
+    private var inRoute = false
+    private var inTrack = false
+    private var inMetadata = false
+
+    private let isoFormatter = ISO8601DateFormatter()
+
+    init(xmlString: String) {
+        self.xmlString = xmlString
+    }
+
+    func parse() -> GPXData? {
+        guard let data = xmlString.data(using: .utf8) else { return nil }
+        let parser = XMLParser(data: data)
+        parser.delegate = self
+        guard parser.parse() else { return nil }
+        return GPXData(name: name, waypoints: waypoints, trackPoints: trackPoints)
+    }
+
+    func parser(_ parser: XMLParser, didStartElement elementName: String, namespaceURI: String?, qualifiedName: String?, attributes: [String: String] = [:]) {
+        currentElement = elementName
+        currentText = ""
+
+        switch elementName {
+        case "metadata": inMetadata = true
+        case "rte": inRoute = true
+        case "trk", "trkseg": inTrack = true
+        case "rtept", "wpt":
+            currentLat = Double(attributes["lat"] ?? "")
+            currentLon = Double(attributes["lon"] ?? "")
+            currentName = nil
+        case "trkpt":
+            currentLat = Double(attributes["lat"] ?? "")
+            currentLon = Double(attributes["lon"] ?? "")
+            currentElevation = nil
+            currentTime = nil
+        default: break
+        }
+    }
+
+    func parser(_ parser: XMLParser, foundCharacters string: String) {
+        currentText += string
+    }
+
+    func parser(_ parser: XMLParser, didEndElement elementName: String, namespaceURI: String?, qualifiedName: String?) {
+        let text = currentText.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        switch elementName {
+        case "metadata": inMetadata = false
+        case "name":
+            if inMetadata { name = text }
+            else if inRoute || !inTrack { currentName = text }
+        case "ele": currentElevation = Double(text)
+        case "time":
+            if !inMetadata { currentTime = isoFormatter.date(from: text) }
+        case "rtept", "wpt":
+            if let lat = currentLat, let lon = currentLon {
+                waypoints.append(GPXWaypoint(latitude: lat, longitude: lon, name: currentName))
+            }
+        case "trkpt":
+            if let lat = currentLat, let lon = currentLon {
+                trackPoints.append(GPXTrackPoint(latitude: lat, longitude: lon, elevation: currentElevation, time: currentTime))
+            }
+        case "rte": inRoute = false
+        case "trk", "trkseg": inTrack = false
+        default: break
+        }
+    }
+}

--- a/WalkableTests/GPXServiceTests.swift
+++ b/WalkableTests/GPXServiceTests.swift
@@ -1,0 +1,100 @@
+import Testing
+import Foundation
+@testable import WalkableKit
+
+@Suite("GPXService")
+struct GPXServiceTests {
+
+    @Test("Export route produces valid GPX XML")
+    func exportRoute() {
+        let route = Route(name: "Test Route", distance: 1000)
+        let wp1 = Waypoint(index: 0, latitude: 37.7749, longitude: -122.4194)
+        let wp2 = Waypoint(index: 1, latitude: 37.7750, longitude: -122.4190)
+        route.waypoints = [wp1, wp2]
+
+        let gpx = GPXService.export(route: route)
+        #expect(gpx.contains("<gpx"))
+        #expect(gpx.contains("Test Route"))
+        #expect(gpx.contains("37.7749"))
+        #expect(gpx.contains("-122.4194"))
+        #expect(gpx.contains("<rtept"))
+    }
+
+    @Test("Parse GPX with waypoints")
+    func parseWaypoints() {
+        let gpx = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <gpx version="1.1" creator="Walkable" xmlns="http://www.topografix.com/GPX/1/1">
+          <metadata><name>Parsed Route</name></metadata>
+          <rte>
+            <name>Parsed Route</name>
+            <rtept lat="37.7749" lon="-122.4194"><name>Start</name></rtept>
+            <rtept lat="37.7760" lon="-122.4180"><name>End</name></rtept>
+          </rte>
+        </gpx>
+        """
+
+        let data = GPXService.parse(gpxString: gpx)
+        #expect(data != nil)
+        #expect(data?.name == "Parsed Route")
+        #expect(data?.waypoints.count == 2)
+        #expect(data?.waypoints[0].name == "Start")
+        #expect(abs(data!.waypoints[0].latitude - 37.7749) < 0.001)
+    }
+
+    @Test("Parse GPX with track points and elevation")
+    func parseTrackPoints() {
+        let gpx = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <gpx version="1.1" creator="Walkable" xmlns="http://www.topografix.com/GPX/1/1">
+          <metadata><name>Track Test</name></metadata>
+          <trk><trkseg>
+            <trkpt lat="37.7749" lon="-122.4194"><ele>25.0</ele><time>2026-04-06T12:00:00Z</time></trkpt>
+            <trkpt lat="37.7750" lon="-122.4190"><ele>26.5</ele><time>2026-04-06T12:00:30Z</time></trkpt>
+          </trkseg></trk>
+        </gpx>
+        """
+
+        let data = GPXService.parse(gpxString: gpx)
+        #expect(data?.trackPoints.count == 2)
+        #expect(data?.trackPoints[0].elevation == 25.0)
+        #expect(data?.trackPoints[1].time != nil)
+    }
+
+    @Test("Parse empty GPX returns empty data")
+    func parseEmpty() {
+        let gpx = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <gpx version="1.1" creator="test" xmlns="http://www.topografix.com/GPX/1/1">
+        </gpx>
+        """
+        let data = GPXService.parse(gpxString: gpx)
+        #expect(data != nil)
+        #expect(data?.waypoints.isEmpty == true)
+        #expect(data?.trackPoints.isEmpty == true)
+    }
+
+    @Test("Roundtrip: export then parse preserves waypoints")
+    func roundtrip() {
+        let route = Route(name: "Roundtrip Test", distance: 500)
+        let wp1 = Waypoint(index: 0, latitude: -34.5875, longitude: -58.4371, label: "Home")
+        let wp2 = Waypoint(index: 1, latitude: -34.5880, longitude: -58.4365, label: "Park")
+        route.waypoints = [wp1, wp2]
+
+        let gpx = GPXService.export(route: route)
+        let parsed = GPXService.parse(gpxString: gpx)
+
+        #expect(parsed?.name == "Roundtrip Test")
+        #expect(parsed?.waypoints.count == 2)
+        #expect(parsed?.waypoints[0].name == "Home")
+        #expect(abs(parsed!.waypoints[1].latitude - (-34.5880)) < 0.001)
+    }
+
+    @Test("XML special characters are escaped")
+    func escapeXML() {
+        let route = Route(name: "Tom & Jerry's <Route>")
+        let gpx = GPXService.export(route: route)
+        #expect(gpx.contains("Tom &amp; Jerry"))
+        #expect(gpx.contains("&lt;Route&gt;"))
+    }
+}


### PR DESCRIPTION
## What
Import and export walking routes and sessions as GPX files.

## Export
- **Routes**: Export waypoints as `<rtept>` + calculated path as `<trk>` via Share sheet
- **Sessions**: Export GPS track with timestamps as `<trk>` with `<time>` elements
- Accessible from route detail (ellipsis menu) and session detail toolbar

## Import
- Import `.gpx` files from the Library tab (download icon in toolbar)
- Parses waypoints (`<rtept>`/`<wpt>`) and track points (`<trkpt>`)
- Creates a Route with waypoints, polyline, calculated distance, and center position
- Syncs imported route to Watch

## GPX Format
Standard GPX 1.1 with `<rte>` for waypoints, `<trk>` for paths. Includes elevation and timestamps when available.

## Use Case
Export a real walk from the app, generate a GPX simulation file, then use Xcode's GPX location simulation to test features without physically walking.

## Testing
- [x] Builds on iOS
- [x] 54 unit tests pass (6 new GPX tests)
- [x] Export produces valid GPX XML
- [x] Parse handles waypoints, track points, elevation, timestamps
- [x] Roundtrip: export → parse preserves data
- [x] XML special characters escaped

## New Tests
- `GPXServiceTests`: export, parse waypoints, parse track points with elevation, parse empty, roundtrip, XML escaping