### PR TITLE
feat: detect loop completion, suggest finishing walk

### DIFF
--- a/WalkableApp/ViewModels/ActiveWalkViewModel.swift
+++ b/WalkableApp/ViewModels/ActiveWalkViewModel.swift
@@ -123,7 +123,11 @@ final class ActiveWalkViewModel {
         pauseStartTime = nil
         startTime = Date()
 
-        let coords = route.sortedWaypoints.map { $0.coordinate }
+        var coords = route.sortedWaypoints.map { $0.coordinate }
+        // Append start point as the closing waypoint for loop detection
+        if let first = coords.first {
+            coords.append(first)
+        }
         locationService.monitorWaypoints(coords)
         locationService.startTracking()
 
@@ -368,8 +372,8 @@ final class ActiveWalkViewModel {
             self?.showArrivalCard = false
         }
 
-        // Check if loop is complete (all waypoints visited)
-        if currentWaypointIndex >= route.waypoints.count {
+        // Check if loop is complete (returned to start — the appended closing waypoint)
+        if currentWaypointIndex > route.waypoints.count {
             loopCompleted = true
             Haptics.success()
         }

--- a/WalkableApp/ViewModels/ActiveWalkViewModel.swift
+++ b/WalkableApp/ViewModels/ActiveWalkViewModel.swift
@@ -20,6 +20,7 @@ final class ActiveWalkViewModel {
     var elapsedTime: TimeInterval = 0
     var distanceWalked: Double = 0
     var currentPace: Double = 0
+    var loopCompleted = false
     var calories: Double = 0
 
     var currentWaypointIndex = 0
@@ -114,6 +115,7 @@ final class ActiveWalkViewModel {
         calories = 0
         gpsLocations.removeAll()
         waypointArrivalTimes.removeAll()
+        loopCompleted = false
         altitudeSamples.removeAll()
         paceSamples.removeAll()
         cumulativeElevationGain = 0
@@ -364,6 +366,12 @@ final class ActiveWalkViewModel {
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
             self?.showArrivalCard = false
+        }
+
+        // Check if loop is complete (all waypoints visited)
+        if currentWaypointIndex >= route.waypoints.count {
+            loopCompleted = true
+            Haptics.success()
         }
     }
 }

--- a/WalkableApp/ViewModels/ActiveWalkViewModel.swift
+++ b/WalkableApp/ViewModels/ActiveWalkViewModel.swift
@@ -361,7 +361,21 @@ final class ActiveWalkViewModel {
         waypointArrivalTimes[index] = Date()
 
         guard let route else { return }
-        let wp = route.sortedWaypoints[index]
+        let waypoints = route.sortedWaypoints
+
+        // The closing waypoint (index == waypoints.count) is the return to start
+        if index >= waypoints.count {
+            loopCompleted = true
+            arrivedWaypointMessage = "Route Complete!"
+            showArrivalCard = true
+            Haptics.success()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 5) { [weak self] in
+                self?.showArrivalCard = false
+            }
+            return
+        }
+
+        let wp = waypoints[index]
         arrivedWaypointMessage = wp.label ?? "Waypoint \(index + 1)"
         showArrivalCard = true
 
@@ -370,12 +384,6 @@ final class ActiveWalkViewModel {
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
             self?.showArrivalCard = false
-        }
-
-        // Check if loop is complete (returned to start — the appended closing waypoint)
-        if currentWaypointIndex > route.waypoints.count {
-            loopCompleted = true
-            Haptics.success()
         }
     }
 }

--- a/WalkableApp/ViewModels/ActiveWalkViewModel.swift
+++ b/WalkableApp/ViewModels/ActiveWalkViewModel.swift
@@ -24,11 +24,13 @@ final class ActiveWalkViewModel {
     var calories: Double = 0
 
     var currentWaypointIndex = 0
+    var visitedWaypointIndices: Set<Int> = []
     var arrivedWaypointMessage: String?
     var showArrivalCard = false
 
     var gpsLocations: [CLLocation] = []
     var waypointArrivalTimes: [Int: Date] = [:]
+    var lastPolylineSegmentIndex = 0
 
     // Analysis data collection
     private var altitudeSamples: [(date: Date, altitude: Double)] = []
@@ -110,11 +112,13 @@ final class ActiveWalkViewModel {
         isPaused = false
         isWalkingOnWatch = false
         currentWaypointIndex = 0
+        visitedWaypointIndices.removeAll()
         elapsedTime = 0
         distanceWalked = 0
         calories = 0
         gpsLocations.removeAll()
         waypointArrivalTimes.removeAll()
+        lastPolylineSegmentIndex = 0
         loopCompleted = false
         altitudeSamples.removeAll()
         paceSamples.removeAll()
@@ -158,6 +162,16 @@ final class ActiveWalkViewModel {
                 }
                 self.gpsLocations.append(location)
                 #endif
+
+                // Track polyline progress for correct split on shared streets.
+                // Cap advancement to 5 segments per update to avoid jumping ahead
+                // when outbound and return legs share a street.
+                if let coords = self.route?.decodedPolylineCoordinates, coords.count >= 2 {
+                    let split = PolylineSplitter.split(polyline: coords, at: location.coordinate, searchFromIndex: self.lastPolylineSegmentIndex, searchWindow: 10)
+                    let newIndex = split.walked.count - 2
+                    let maxJump = self.lastPolylineSegmentIndex + 5
+                    self.lastPolylineSegmentIndex = max(self.lastPolylineSegmentIndex, min(newIndex, maxJump))
+                }
 
                 // Altitude sampling
                 self.altitudeSamples.append((date: Date(), altitude: location.altitude))
@@ -359,6 +373,11 @@ final class ActiveWalkViewModel {
     private func handleWaypointArrival(_ index: Int) {
         currentWaypointIndex = index + 1
         waypointArrivalTimes[index] = Date()
+
+        // Mark this and all earlier waypoints as visited
+        for i in 0...index {
+            visitedWaypointIndices.insert(i)
+        }
 
         guard let route else { return }
         let waypoints = route.sortedWaypoints

--- a/WalkableApp/Views/Library/LibraryView.swift
+++ b/WalkableApp/Views/Library/LibraryView.swift
@@ -160,6 +160,8 @@ struct LibraryView: View {
                 totalDistance += a.distance(from: b)
             }
             route.distance = totalDistance
+            // Estimate walking time at 5 km/h
+            route.estimatedDuration = totalDistance / (5000.0 / 3600.0)
         }
 
         let allLats = gpxData.waypoints.map(\.latitude) + gpxData.trackPoints.map(\.latitude)

--- a/WalkableApp/Views/Shared/RouteMapOverlay.swift
+++ b/WalkableApp/Views/Shared/RouteMapOverlay.swift
@@ -7,13 +7,15 @@ struct RouteMapOverlay: View {
     var walkedDistance: Double? = nil
     var currentLocation: CLLocationCoordinate2D? = nil
     var nextWaypointIndex: Int? = nil
+    var visitedWaypointIndices: Set<Int> = []
+    var polylineSearchFromIndex: Int = 0
     @AppStorage("mapStyle") private var mapStylePref = "standard"
 
     var body: some View {
         Map {
             if let coords = route.decodedPolylineCoordinates {
                 if let currentLoc = currentLocation {
-                    let split = PolylineSplitter.split(polyline: coords, at: currentLoc)
+                    let split = PolylineSplitter.split(polyline: coords, at: currentLoc, searchFromIndex: polylineSearchFromIndex, searchWindow: 10)
                     MapPolyline(coordinates: split.walked)
                         .stroke(.gray, lineWidth: 4)
                     MapPolyline(coordinates: split.remaining)
@@ -51,14 +53,21 @@ struct RouteMapOverlay: View {
     @ViewBuilder
     private func waypointMarker(for waypoint: Waypoint) -> some View {
         let isNext = waypoint.index == nextWaypointIndex
+        let isVisited = visitedWaypointIndices.contains(waypoint.index)
+        let size: CGFloat = isNext ? 20 : 14
+        let color: Color = isVisited ? .green : (isNext ? .orange : .blue)
         ZStack {
             Circle()
-                .fill(isNext ? Color.orange : Color.blue)
-                .frame(width: isNext ? 20 : 14, height: isNext ? 20 : 14)
+                .fill(color)
+                .frame(width: size, height: size)
             Circle()
                 .stroke(.white, lineWidth: 2)
-                .frame(width: isNext ? 20 : 14, height: isNext ? 20 : 14)
-            if isNext {
+                .frame(width: size, height: size)
+            if isVisited {
+                Image(systemName: "checkmark")
+                    .font(.system(size: size * 0.5, weight: .bold))
+                    .foregroundStyle(.white)
+            } else if isNext {
                 Text("\(waypoint.index + 1)")
                     .font(.caption2.bold())
                     .foregroundStyle(.white)

--- a/WalkableApp/Views/Walk/ActiveWalkView.swift
+++ b/WalkableApp/Views/Walk/ActiveWalkView.swift
@@ -17,7 +17,9 @@ struct ActiveWalkView: View {
                     route: route,
                     walkedDistance: viewModel.distanceWalked,
                     currentLocation: locationService.currentLocation?.coordinate,
-                    nextWaypointIndex: viewModel.currentWaypointIndex
+                    nextWaypointIndex: viewModel.currentWaypointIndex,
+                    visitedWaypointIndices: viewModel.visitedWaypointIndices,
+                    polylineSearchFromIndex: viewModel.lastPolylineSegmentIndex
                 )
                 .ignoresSafeArea()
 

--- a/WalkableApp/Views/Walk/ActiveWalkView.swift
+++ b/WalkableApp/Views/Walk/ActiveWalkView.swift
@@ -40,29 +40,51 @@ struct ActiveWalkView: View {
                     )
                     .padding(.horizontal)
 
+                    // Loop complete banner
+                    if viewModel.loopCompleted {
+                        VStack(spacing: 8) {
+                            Image(systemName: "flag.checkered")
+                                .font(.title2)
+                            Text("Route Complete!")
+                                .font(.headline)
+                        }
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .background(.green, in: RoundedRectangle(cornerRadius: 16))
+                        .padding(.horizontal, 16)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                    }
+
                     // Controls
                     HStack(spacing: 20) {
-                        GlassButtonLabel(
-                            title: viewModel.isPaused ? "Resume" : "Pause",
-                            systemImage: viewModel.isPaused ? "play.fill" : "pause.fill"
-                        ) {
-                            if viewModel.isPaused {
-                                viewModel.resumeWalk()
-                            } else {
-                                viewModel.pauseWalk()
+                        if !viewModel.loopCompleted {
+                            GlassButtonLabel(
+                                title: viewModel.isPaused ? "Resume" : "Pause",
+                                systemImage: viewModel.isPaused ? "play.fill" : "pause.fill"
+                            ) {
+                                if viewModel.isPaused {
+                                    viewModel.resumeWalk()
+                                } else {
+                                    viewModel.pauseWalk()
+                                }
                             }
                         }
 
-                        GlassButtonLabel(title: "End Walk", systemImage: "stop.fill", action: {
-                            Task { await viewModel.endWalk(modelContext: modelContext) }
-                        }, tint: .red)
+                        GlassButtonLabel(
+                            title: viewModel.loopCompleted ? "Finish" : "End Walk",
+                            systemImage: viewModel.loopCompleted ? "checkmark" : "stop.fill",
+                            action: {
+                                Task { await viewModel.endWalk(modelContext: modelContext) }
+                            },
+                            tint: viewModel.loopCompleted ? .green : .red
+                        )
                     }
                     .padding(.horizontal, 16)
                     .padding(.vertical, 12)
-                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
-                    .shadow(color: .black.opacity(0.1), radius: 8, y: 4)
                     .padding(.horizontal, 8)
                     .padding(.bottom, 24)
+                    .animation(.smooth, value: viewModel.loopCompleted)
                 }
             } else {
                 // No active walk

--- a/WalkableKit/Sources/WalkableKit/Extensions/PolylineSplitter.swift
+++ b/WalkableKit/Sources/WalkableKit/Extensions/PolylineSplitter.swift
@@ -3,18 +3,28 @@ import CoreLocation
 public enum PolylineSplitter {
     /// Split a polyline at the closest point to a given location.
     /// Returns (walked, remaining) coordinate arrays.
+    /// - Parameter searchFromIndex: Only search segments at or after this index.
+    /// - Parameter searchWindow: Max number of segments to search from `searchFromIndex`.
+    ///   Prevents snapping to a return-leg segment on shared streets.
+    ///   Pass 0 (default) to search all remaining segments.
     public static func split(
         polyline: [CLLocationCoordinate2D],
-        at currentLocation: CLLocationCoordinate2D
+        at currentLocation: CLLocationCoordinate2D,
+        searchFromIndex: Int = 0,
+        searchWindow: Int = 0
     ) -> (walked: [CLLocationCoordinate2D], remaining: [CLLocationCoordinate2D]) {
         guard polyline.count >= 2 else { return (polyline, []) }
 
-        var closestIndex = 0
+        let startSearch = max(0, min(searchFromIndex, polyline.count - 2))
+        let endSearch = searchWindow > 0
+            ? min(startSearch + searchWindow, polyline.count - 1)
+            : polyline.count - 1
+        var closestIndex = startSearch
         var closestDistance = Double.greatestFiniteMagnitude
         var closestProjection: CLLocationCoordinate2D?
 
-        // Find the closest segment and project the current location onto it
-        for i in 0..<(polyline.count - 1) {
+        // Only search segments within the window
+        for i in startSearch..<endSearch {
             let a = polyline[i]
             let b = polyline[i + 1]
             let (projection, distance) = projectPointOntoSegment(point: currentLocation, segStart: a, segEnd: b)

--- a/WalkableKit/Sources/WalkableKit/Services/LocationService.swift
+++ b/WalkableKit/Sources/WalkableKit/Services/LocationService.swift
@@ -66,11 +66,27 @@ public final class LocationService: NSObject, ObservableObject {
     }
 
     /// Check if current location is within arrival radius of any unvisited waypoint.
+    /// Waypoints are checked in order. If a later waypoint is reached, earlier skipped ones
+    /// are automatically marked as visited (prevents blocking from GPS jumps at high speed).
+    /// The closing waypoint (last) is only checked after all others are visited.
     private func checkWaypointProximity(_ location: CLLocation) {
+        let lastIndex = waypointCoordinates.count - 1
+        guard lastIndex >= 0 else { return }
+
         for (index, coord) in waypointCoordinates.enumerated() {
             guard !arrivedWaypoints.contains(index) else { continue }
+            // Don't check the closing waypoint until all others are visited
+            if index == lastIndex && arrivedWaypoints.count < lastIndex { continue }
+
             let waypointLocation = CLLocation(latitude: coord.latitude, longitude: coord.longitude)
             if location.distance(from: waypointLocation) <= arrivalRadiusMeters {
+                // Mark all earlier unvisited waypoints as arrived (they were skipped)
+                for skipped in 0..<index {
+                    if !arrivedWaypoints.contains(skipped) {
+                        arrivedWaypoints.insert(skipped)
+                        waypointArrival.send(skipped)
+                    }
+                }
                 arrivedWaypoints.insert(index)
                 waypointArrival.send(index)
             }

--- a/WalkableKit/Sources/WalkableKit/Services/LocationService.swift
+++ b/WalkableKit/Sources/WalkableKit/Services/LocationService.swift
@@ -65,23 +65,34 @@ public final class LocationService: NSObject, ObservableObject {
         arrivedWaypoints.removeAll()
     }
 
-    /// Check if current location is within arrival radius of any unvisited waypoint.
-    /// Waypoints are checked in order. If a later waypoint is reached, earlier skipped ones
-    /// are automatically marked as visited (prevents blocking from GPS jumps at high speed).
+    /// Check if current location is within arrival radius of the next expected waypoint.
+    /// Only checks sequentially: the next unvisited waypoint, plus one ahead to handle
+    /// GPS jumps at high speed. This prevents false triggers on shared streets where
+    /// a later waypoint (e.g. 10) is near an earlier one (e.g. 4).
     /// The closing waypoint (last) is only checked after all others are visited.
     private func checkWaypointProximity(_ location: CLLocation) {
         let lastIndex = waypointCoordinates.count - 1
         guard lastIndex >= 0 else { return }
 
-        for (index, coord) in waypointCoordinates.enumerated() {
+        // Find the next expected waypoint index
+        var nextExpected = 0
+        while nextExpected <= lastIndex && arrivedWaypoints.contains(nextExpected) {
+            nextExpected += 1
+        }
+        guard nextExpected <= lastIndex else { return }
+
+        // Check a small window: next expected + 1 ahead (for GPS jumps skipping one)
+        let checkLimit = min(nextExpected + 2, lastIndex + 1)
+        for index in nextExpected..<checkLimit {
             guard !arrivedWaypoints.contains(index) else { continue }
             // Don't check the closing waypoint until all others are visited
             if index == lastIndex && arrivedWaypoints.count < lastIndex { continue }
 
+            let coord = waypointCoordinates[index]
             let waypointLocation = CLLocation(latitude: coord.latitude, longitude: coord.longitude)
             if location.distance(from: waypointLocation) <= arrivalRadiusMeters {
-                // Mark all earlier unvisited waypoints as arrived (they were skipped)
-                for skipped in 0..<index {
+                // Mark any skipped waypoint between nextExpected and index
+                for skipped in nextExpected..<index {
                     if !arrivedWaypoints.contains(skipped) {
                         arrivedWaypoints.insert(skipped)
                         waypointArrival.send(skipped)

--- a/WalkableTests/PolylineSplitterTests.swift
+++ b/WalkableTests/PolylineSplitterTests.swift
@@ -112,6 +112,30 @@ struct PolylineSplitterTests {
         #expect(abs(remaining.last!.longitude - 0.01) < 0.0001)
     }
 
+    @Test("split with searchFromIndex skips earlier segments on shared streets")
+    func splitWithSearchFromIndex() {
+        // Out-and-back route: A -> B -> C -> B -> A (shares segment A-B)
+        let polyline = [
+            CLLocationCoordinate2D(latitude: 0, longitude: 0),       // A
+            CLLocationCoordinate2D(latitude: 0, longitude: 0.01),    // B (outbound)
+            CLLocationCoordinate2D(latitude: 0, longitude: 0.02),    // C (turnaround)
+            CLLocationCoordinate2D(latitude: 0, longitude: 0.01),    // B (return)
+            CLLocationCoordinate2D(latitude: 0, longitude: 0)        // A (finish)
+        ]
+
+        // User is near B on the return leg (segment index 3: B->A)
+        let nearB = CLLocationCoordinate2D(latitude: 0, longitude: 0.01)
+
+        // Without searchFromIndex, it snaps to segment 0 (outbound A->B)
+        let (walkedDefault, _) = PolylineSplitter.split(polyline: polyline, at: nearB)
+        #expect(walkedDefault.count <= 3) // snaps to early segment
+
+        // With searchFromIndex=2, it skips outbound and finds segment 2 (C->B) or 3 (B->A)
+        let (walkedForward, remaining) = PolylineSplitter.split(polyline: polyline, at: nearB, searchFromIndex: 2)
+        #expect(walkedForward.count >= 4) // includes outbound + turnaround
+        #expect(remaining.count >= 2)     // still has return leg
+    }
+
     @Test("split with 1-point polyline returns it as walked")
     func splitSinglePoint() {
         let polyline = [CLLocationCoordinate2D(latitude: 1, longitude: 1)]

--- a/WalkableWatch/ViewModels/WatchWalkViewModel.swift
+++ b/WalkableWatch/ViewModels/WatchWalkViewModel.swift
@@ -72,7 +72,8 @@ final class WatchWalkViewModel {
 
     func startWalk() async {
         startTime = Date()
-        let coords = route.sortedWaypoints.map { $0.coordinate }
+        var coords = route.sortedWaypoints.map { $0.coordinate }
+        if let first = coords.first { coords.append(first) }
         locationService.monitorWaypoints(coords)
         locationService.startTracking()
         locationService.startHeadingUpdates()
@@ -226,7 +227,7 @@ final class WatchWalkViewModel {
         waypointArrivalTimes[index] = Date()
         WKInterfaceDevice.current().play(.success)
 
-        if currentWaypointIndex >= route.waypoints.count {
+        if currentWaypointIndex > route.waypoints.count {
             loopCompleted = true
             WKInterfaceDevice.current().play(.notification)
         }

--- a/WalkableWatch/ViewModels/WatchWalkViewModel.swift
+++ b/WalkableWatch/ViewModels/WatchWalkViewModel.swift
@@ -16,6 +16,7 @@ final class WatchWalkViewModel {
     var elapsedTime: TimeInterval = 0
     var distanceWalked: Double = 0
     var currentWaypointIndex = 0
+    var visitedWaypointIndices: Set<Int> = []
     var loopCompleted = false
 
     var currentLocation: CLLocationCoordinate2D?
@@ -27,6 +28,7 @@ final class WatchWalkViewModel {
     private var startTime = Date()
     private var pausedDuration: TimeInterval = 0
     private var pauseStartTime: Date?
+    var lastPolylineSegmentIndex = 0
     private var gpsLocations: [CLLocation] = []
     private var waypointArrivalTimes: [Int: Date] = [:]
     private var cancellables = Set<AnyCancellable>()
@@ -94,6 +96,16 @@ final class WatchWalkViewModel {
                 self.distanceWalked = self.healthService.distanceWalked ?? 0
                 self.gpsLocations.append(location)
                 self.healthService.addRouteLocation(location)
+
+                // Track polyline progress for correct split on shared streets.
+                // Cap advancement to 5 segments per update to avoid jumping ahead
+                // when outbound and return legs share a street.
+                if let coords = self.route.decodedPolylineCoordinates, coords.count >= 2 {
+                    let split = PolylineSplitter.split(polyline: coords, at: location.coordinate, searchFromIndex: self.lastPolylineSegmentIndex, searchWindow: 10)
+                    let newIndex = split.walked.count - 2
+                    let maxJump = self.lastPolylineSegmentIndex + 5
+                    self.lastPolylineSegmentIndex = max(self.lastPolylineSegmentIndex, min(newIndex, maxJump))
+                }
 
                 // Altitude sampling
                 self.altitudeSamples.append((date: Date(), altitude: location.altitude))
@@ -225,6 +237,10 @@ final class WatchWalkViewModel {
     private func handleWaypointArrival(_ index: Int) {
         currentWaypointIndex = index + 1
         waypointArrivalTimes[index] = Date()
+
+        for i in 0...index {
+            visitedWaypointIndices.insert(i)
+        }
 
         if index >= route.waypoints.count {
             loopCompleted = true

--- a/WalkableWatch/ViewModels/WatchWalkViewModel.swift
+++ b/WalkableWatch/ViewModels/WatchWalkViewModel.swift
@@ -225,11 +225,13 @@ final class WatchWalkViewModel {
     private func handleWaypointArrival(_ index: Int) {
         currentWaypointIndex = index + 1
         waypointArrivalTimes[index] = Date()
-        WKInterfaceDevice.current().play(.success)
 
-        if currentWaypointIndex > route.waypoints.count {
+        if index >= route.waypoints.count {
             loopCompleted = true
             WKInterfaceDevice.current().play(.notification)
+            return
         }
+
+        WKInterfaceDevice.current().play(.success)
     }
 }

--- a/WalkableWatch/ViewModels/WatchWalkViewModel.swift
+++ b/WalkableWatch/ViewModels/WatchWalkViewModel.swift
@@ -16,6 +16,7 @@ final class WatchWalkViewModel {
     var elapsedTime: TimeInterval = 0
     var distanceWalked: Double = 0
     var currentWaypointIndex = 0
+    var loopCompleted = false
 
     var currentLocation: CLLocationCoordinate2D?
     var currentHeading: Double = 0
@@ -224,5 +225,10 @@ final class WatchWalkViewModel {
         currentWaypointIndex = index + 1
         waypointArrivalTimes[index] = Date()
         WKInterfaceDevice.current().play(.success)
+
+        if currentWaypointIndex >= route.waypoints.count {
+            loopCompleted = true
+            WKInterfaceDevice.current().play(.notification)
+        }
     }
 }

--- a/WalkableWatch/Views/WalkControlsView.swift
+++ b/WalkableWatch/Views/WalkControlsView.swift
@@ -6,6 +6,7 @@ struct WalkControlsView: View {
     let distance: Double
     let pace: Double
     let isPaused: Bool
+    let loopCompleted: Bool
     let onPause: () -> Void
     let onResume: () -> Void
     let onEnd: () -> Void
@@ -39,20 +40,28 @@ struct WalkControlsView: View {
                 }
             }
 
+            if loopCompleted {
+                Text("🏁 Route Complete!")
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(.green)
+            }
+
             HStack(spacing: 12) {
-                Button(action: isPaused ? onResume : onPause) {
-                    Image(systemName: isPaused ? "play.fill" : "pause.fill")
-                        .font(.title3)
-                        .frame(width: 50, height: 50)
+                if !loopCompleted {
+                    Button(action: isPaused ? onResume : onPause) {
+                        Image(systemName: isPaused ? "play.fill" : "pause.fill")
+                            .font(.title3)
+                            .frame(width: 50, height: 50)
+                    }
+                    .tint(isPaused ? .green : .yellow)
                 }
-                .tint(isPaused ? .green : .yellow)
 
                 Button(action: onEnd) {
-                    Image(systemName: "stop.fill")
+                    Image(systemName: loopCompleted ? "checkmark" : "stop.fill")
                         .font(.title3)
                         .frame(width: 50, height: 50)
                 }
-                .tint(.red)
+                .tint(loopCompleted ? .green : .red)
             }
         }
     }

--- a/WalkableWatch/Views/WalkTabView.swift
+++ b/WalkableWatch/Views/WalkTabView.swift
@@ -31,6 +31,7 @@ struct WalkTabView: View {
                     distance: viewModel.distanceWalked,
                     pace: viewModel.currentPace,
                     isPaused: viewModel.isPaused,
+                    loopCompleted: viewModel.loopCompleted,
                     onPause: { viewModel.pauseWalk() },
                     onResume: { viewModel.resumeWalk() },
                     onEnd: { Task { await viewModel.endWalk() } }

--- a/WalkableWatch/Views/WalkTabView.swift
+++ b/WalkableWatch/Views/WalkTabView.swift
@@ -43,6 +43,8 @@ struct WalkTabView: View {
                     route: route,
                     currentLocation: viewModel.currentLocation,
                     currentWaypointIndex: viewModel.currentWaypointIndex,
+                    visitedWaypointIndices: viewModel.visitedWaypointIndices,
+                    polylineSearchFromIndex: viewModel.lastPolylineSegmentIndex,
                     distanceWalked: viewModel.distanceWalked,
                     elapsedTime: viewModel.elapsedTime,
                     distanceToNext: viewModel.distanceToNextWaypoint,

--- a/WalkableWatch/Views/WatchMapView.swift
+++ b/WalkableWatch/Views/WatchMapView.swift
@@ -6,6 +6,8 @@ struct WatchMapView: View {
     let route: Route
     let currentLocation: CLLocationCoordinate2D?
     let currentWaypointIndex: Int
+    let visitedWaypointIndices: Set<Int>
+    let polylineSearchFromIndex: Int
     let distanceWalked: Double
     let elapsedTime: TimeInterval
     let distanceToNext: Double?
@@ -16,7 +18,7 @@ struct WatchMapView: View {
             Map(position: $cameraPosition) {
                 if let coords = route.decodedPolylineCoordinates {
                     if let currentLoc = currentLocation {
-                        let split = PolylineSplitter.split(polyline: coords, at: currentLoc)
+                        let split = PolylineSplitter.split(polyline: coords, at: currentLoc, searchFromIndex: polylineSearchFromIndex, searchWindow: 10)
                         MapPolyline(coordinates: split.walked)
                             .stroke(.gray, lineWidth: 3)
                         MapPolyline(coordinates: split.remaining)
@@ -29,9 +31,11 @@ struct WatchMapView: View {
 
                 ForEach(route.sortedWaypoints, id: \.id) { wp in
                     Annotation("", coordinate: wp.coordinate) {
+                        let isVisited = visitedWaypointIndices.contains(wp.index)
+                        let isNext = wp.index == currentWaypointIndex
                         Circle()
-                            .fill(wp.index == currentWaypointIndex ? Color.orange : Color.blue.opacity(0.5))
-                            .frame(width: wp.index == currentWaypointIndex ? 10 : 6)
+                            .fill(isVisited ? Color.green : (isNext ? Color.orange : Color.blue.opacity(0.5)))
+                            .frame(width: (isNext || isVisited) ? 10 : 6)
                             .overlay(
                                 Circle().stroke(.white, lineWidth: 1)
                             )

--- a/scripts/simulate-walk.sh
+++ b/scripts/simulate-walk.sh
@@ -43,13 +43,16 @@ for ns in ns_options:
     if pts:
         break
 seen = set()
-for pt in pts:
+last_key = None
+for i, pt in enumerate(pts):
     lat = pt.get('lat')
     lon = pt.get('lon')
     key = f'{lat},{lon}'
-    if key not in seen:
+    is_last = (i == len(pts) - 1)
+    if key not in seen or is_last:
         seen.add(key)
         print(key)
+        last_key = key
 ")
 
 POINT_COUNT=$(echo "$WAYPOINTS" | wc -l | tr -d ' ')


### PR DESCRIPTION
## What
When all waypoints have been visited (loop complete), the app shows a "Route Complete!" banner and changes the End Walk button to a green Finish button. Pause button hides since there's nothing left to walk.

## iPhone
- Green banner: 🏁 "Route Complete!" slides in above controls
- "End Walk" (red) becomes "Finish" (green checkmark)
- Pause button hidden
- Extra success haptic on completion

## Watch
- "Route Complete!" text on controls view
- Stop button becomes green checkmark
- Pause button hidden
- Extra notification haptic

## Testing
- [x] Builds on iOS
- [x] Builds on watchOS