### PR TITLE
fix: Dynamic Island layout, intents, background location

### DIFF
--- a/WalkableApp/ContentView.swift
+++ b/WalkableApp/ContentView.swift
@@ -95,6 +95,11 @@ struct ContentView: View {
         .onChange(of: walkViewModel.pendingWatchSession?.routeId) {
             saveWatchSession()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .endWalkFromDI)) { _ in
+            Task {
+                await walkViewModel.endWalk(modelContext: modelContext)
+            }
+        }
     }
 
     private func saveWatchSession() {

--- a/WalkableApp/ContentView.swift
+++ b/WalkableApp/ContentView.swift
@@ -92,7 +92,8 @@ struct ContentView: View {
         .onChange(of: allRoutes.count) {
             SyncService.shared.syncAllRoutes(allRoutes)
         }
-        .onChange(of: walkViewModel.pendingWatchSession?.routeId) {
+        .onReceive(SyncService.shared.sessionSyncReceived) { payload in
+            walkViewModel.pendingWatchSession = payload
             saveWatchSession()
         }
         .onReceive(NotificationCenter.default.publisher(for: .endWalkFromDI)) { _ in

--- a/WalkableApp/Info.plist
+++ b/WalkableApp/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>location</string>
+	</array>
+</dict>
+</plist>

--- a/WalkableApp/ViewModels/ActiveWalkViewModel.swift
+++ b/WalkableApp/ViewModels/ActiveWalkViewModel.swift
@@ -5,6 +5,10 @@ import SwiftData
 import ActivityKit
 import WalkableKit
 
+extension Notification.Name {
+    static let endWalkFromDI = Notification.Name("endWalkFromDI")
+}
+
 @MainActor
 @Observable
 final class ActiveWalkViewModel {
@@ -44,12 +48,40 @@ final class ActiveWalkViewModel {
     private var cancellables = Set<AnyCancellable>()
     private var walkCancellables = Set<AnyCancellable>()
     private var liveActivity: Activity<WalkActivityAttributes>?
+    private var liveActivityUpdateTask: Task<Void, Never>?
 
     private let locationService = LocationService.shared
     private let healthService = HealthService.shared
 
     init() {
         listenForWatchWalkStatus()
+        listenForTogglePause()
+    }
+
+    private func listenForTogglePause() {
+        let center = CFNotificationCenterGetDarwinNotifyCenter()
+        let observer = Unmanaged.passUnretained(self).toOpaque()
+        CFNotificationCenterAddObserver(center, observer, { _, observer, _, _, _ in
+            guard let observer else { return }
+            let vm = Unmanaged<ActiveWalkViewModel>.fromOpaque(observer).takeUnretainedValue()
+            Task { @MainActor in
+                if vm.isPaused {
+                    vm.resumeWalk()
+                } else {
+                    vm.pauseWalk()
+                }
+            }
+        }, "com.walkable.togglePause" as CFString, nil, .deliverImmediately)
+
+        CFNotificationCenterAddObserver(center, observer, { _, observer, _, _, _ in
+            guard let observer else { return }
+            let vm = Unmanaged<ActiveWalkViewModel>.fromOpaque(observer).takeUnretainedValue()
+            Task { @MainActor in
+                guard vm.isWalking else { return }
+                // Need modelContext — post a notification the ContentView can handle
+                NotificationCenter.default.post(name: .endWalkFromDI, object: nil)
+            }
+        }, "com.walkable.endWalk" as CFString, nil, .deliverImmediately)
     }
 
     private func listenForWatchWalkStatus() {
@@ -192,6 +224,16 @@ final class ActiveWalkViewModel {
                     self.paceSamples.append((date: Date(), pace: (self.elapsedTime / (self.distanceWalked / 1000)) / 60))
                 }
                 self.healthService.addRouteLocation(location)
+
+                // Update elapsed time + Live Activity from location callback
+                // (Timer stops in background, but location updates keep firing)
+                if let start = self.startTime, !self.isPaused {
+                    self.elapsedTime = Date().timeIntervalSince(start) - self.pausedDuration
+                    if self.distanceWalked > 20 {
+                        self.currentPace = self.elapsedTime / (self.distanceWalked / 1000)
+                    }
+                }
+                self.updateLiveActivity()
             }
             .store(in: &walkCancellables)
 
@@ -200,9 +242,10 @@ final class ActiveWalkViewModel {
                 guard let self, !self.isPaused, let start = self.startTime else { return }
                 self.elapsedTime = Date().timeIntervalSince(start) - self.pausedDuration
                 if self.distanceWalked > 20 {
-                    self.currentPace = self.elapsedTime / (self.distanceWalked / 1000) // sec/km
+                    self.currentPace = self.elapsedTime / (self.distanceWalked / 1000)
                 }
-                self.updateLiveActivity()
+                // Don't update Live Activity here — .timer style auto-ticks.
+                // Location callback handles distance/waypoint updates.
             }
         }
 
@@ -247,7 +290,8 @@ final class ActiveWalkViewModel {
             isPaused: isPaused,
             timerStart: isPaused ? Date.distantFuture : timerStart
         )
-        Task { await liveActivity?.update(.init(state: state, staleDate: nil)) }
+        liveActivityUpdateTask?.cancel()
+        liveActivityUpdateTask = Task { await liveActivity?.update(.init(state: state, staleDate: nil)) }
     }
 
     private func endLiveActivity() {

--- a/WalkableApp/ViewModels/ActiveWalkViewModel.swift
+++ b/WalkableApp/ViewModels/ActiveWalkViewModel.swift
@@ -105,17 +105,14 @@ final class ActiveWalkViewModel {
             }
             .store(in: &cancellables)
 
-        // Also listen for session sync (results from Watch)
+        // Listen for session sync to update Watch walk state
         SyncService.shared.sessionSyncReceived
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] payload in
-                guard let self else { return }
-                self.pendingWatchSession = payload
-                if self.isWalkingOnWatch {
-                    self.isWalkingOnWatch = false
-                    self.isWalking = false
-                    self.route = nil
-                }
+            .sink { [weak self] _ in
+                guard let self, self.isWalkingOnWatch else { return }
+                self.isWalkingOnWatch = false
+                self.isWalking = false
+                self.route = nil
             }
             .store(in: &cancellables)
     }

--- a/WalkableApp/ViewModels/ActiveWalkViewModel.swift
+++ b/WalkableApp/ViewModels/ActiveWalkViewModel.swift
@@ -237,6 +237,19 @@ final class ActiveWalkViewModel {
             }
             .store(in: &walkCancellables)
 
+        // Background-safe Live Activity updates via NotificationCenter
+        // (Combine publishers and Timer stop in background, but CLLocationManager delegate keeps firing)
+        NotificationCenter.default.publisher(for: .locationDidUpdate)
+            .sink { [weak self] _ in
+                guard let self, !self.isPaused, let start = self.startTime else { return }
+                self.elapsedTime = Date().timeIntervalSince(start) - self.pausedDuration
+                if self.distanceWalked > 20 {
+                    self.currentPace = self.elapsedTime / (self.distanceWalked / 1000)
+                }
+                self.updateLiveActivity()
+            }
+            .store(in: &walkCancellables)
+
         timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
             Task { @MainActor [weak self] in
                 guard let self, !self.isPaused, let start = self.startTime else { return }
@@ -244,8 +257,9 @@ final class ActiveWalkViewModel {
                 if self.distanceWalked > 20 {
                     self.currentPace = self.elapsedTime / (self.distanceWalked / 1000)
                 }
-                // Don't update Live Activity here — .timer style auto-ticks.
-                // Location callback handles distance/waypoint updates.
+                // Update Live Activity for distance/waypoint changes.
+                // Timer auto-ticks via .timer style, so this won't cause blink.
+                self.updateLiveActivity()
             }
         }
 

--- a/WalkableApp/Views/Create/PinModeOverlay.swift
+++ b/WalkableApp/Views/Create/PinModeOverlay.swift
@@ -49,6 +49,7 @@ struct PinModeOverlay: View {
                     .padding(.horizontal, 16)
                     .padding(.vertical, 8)
                     .glassEffect(.regular, in: .capsule)
+                    .allowsHitTesting(false)
             }
         }
         .padding(.bottom, 2)

--- a/WalkableKit/Sources/WalkableKit/Intents/EndWalkIntent.swift
+++ b/WalkableKit/Sources/WalkableKit/Intents/EndWalkIntent.swift
@@ -1,0 +1,25 @@
+#if canImport(AppIntents) && canImport(ActivityKit)
+import AppIntents
+
+#if os(iOS)
+@available(iOS 16.1, *)
+public struct EndWalkIntent: LiveActivityIntent {
+    public static let title: LocalizedStringResource = "End Walk"
+    public static let description: IntentDescription = "End the current walk and save progress"
+
+    public init() {}
+
+    public func perform() async throws -> some IntentResult {
+        let name = CFNotificationName("com.walkable.endWalk" as CFString)
+        CFNotificationCenterPostNotification(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            name,
+            nil,
+            nil,
+            true
+        )
+        return .result()
+    }
+}
+#endif
+#endif

--- a/WalkableKit/Sources/WalkableKit/Intents/TogglePauseIntent.swift
+++ b/WalkableKit/Sources/WalkableKit/Intents/TogglePauseIntent.swift
@@ -1,0 +1,25 @@
+#if canImport(AppIntents) && canImport(ActivityKit)
+import AppIntents
+
+#if os(iOS)
+@available(iOS 16.1, *)
+public struct TogglePauseIntent: LiveActivityIntent {
+    public static let title: LocalizedStringResource = "Toggle Pause"
+    public static let description: IntentDescription = "Pause or resume the current walk"
+
+    public init() {}
+
+    public func perform() async throws -> some IntentResult {
+        let name = CFNotificationName("com.walkable.togglePause" as CFString)
+        CFNotificationCenterPostNotification(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            name,
+            nil,
+            nil,
+            true
+        )
+        return .result()
+    }
+}
+#endif
+#endif

--- a/WalkableKit/Sources/WalkableKit/Services/LocationService.swift
+++ b/WalkableKit/Sources/WalkableKit/Services/LocationService.swift
@@ -21,7 +21,7 @@ public final class LocationService: NSObject, ObservableObject {
 
     private var waypointCoordinates: [CLLocationCoordinate2D] = []
     private var arrivedWaypoints: Set<Int> = []
-    private let arrivalRadiusMeters: Double = 25
+    private let arrivalRadiusMeters: Double = 40
 
     private override init() {
         super.init()

--- a/WalkableKit/Sources/WalkableKit/Services/LocationService.swift
+++ b/WalkableKit/Sources/WalkableKit/Services/LocationService.swift
@@ -1,6 +1,10 @@
 @preconcurrency import CoreLocation
 import Combine
 
+public extension Notification.Name {
+    static let locationDidUpdate = Notification.Name("locationDidUpdate")
+}
+
 @MainActor
 public final class LocationService: NSObject, ObservableObject {
     public static let shared = LocationService()
@@ -24,13 +28,6 @@ public final class LocationService: NSObject, ObservableObject {
         manager.delegate = self
         manager.desiredAccuracy = kCLLocationAccuracyBest
         manager.distanceFilter = 5
-        if let modes = Bundle.main.infoDictionary?["UIBackgroundModes"] as? [String],
-           modes.contains("location") {
-            manager.allowsBackgroundLocationUpdates = true
-            #if os(iOS)
-            manager.showsBackgroundLocationIndicator = true
-            #endif
-        }
     }
 
     public func requestAuthorization() {
@@ -38,7 +35,17 @@ public final class LocationService: NSObject, ObservableObject {
     }
 
     public func startTracking() {
+        enableBackgroundLocationIfNeeded()
         manager.startUpdatingLocation()
+    }
+
+    private func enableBackgroundLocationIfNeeded() {
+        guard manager.authorizationStatus == .authorizedWhenInUse ||
+              manager.authorizationStatus == .authorizedAlways else { return }
+        manager.allowsBackgroundLocationUpdates = true
+        #if os(iOS)
+        manager.showsBackgroundLocationIndicator = true
+        #endif
     }
 
     public func stopTracking() {
@@ -136,6 +143,13 @@ extension LocationService: @preconcurrency CLLocationManagerDelegate {
         guard let location = locations.last else { return }
         currentLocation = location
         checkWaypointProximity(location)
+        // Post notification for background Live Activity updates
+        // (Combine publishers stop delivering when app is suspended)
+        NotificationCenter.default.post(
+            name: .locationDidUpdate,
+            object: nil,
+            userInfo: ["location": location]
+        )
     }
 
     public func locationManager(_ manager: CLLocationManager, didUpdateHeading newHeading: CLHeading) {

--- a/WalkableKit/Sources/WalkableKit/Services/LocationService.swift
+++ b/WalkableKit/Sources/WalkableKit/Services/LocationService.swift
@@ -42,9 +42,14 @@ public final class LocationService: NSObject, ObservableObject {
     private func enableBackgroundLocationIfNeeded() {
         guard manager.authorizationStatus == .authorizedWhenInUse ||
               manager.authorizationStatus == .authorizedAlways else { return }
-        manager.allowsBackgroundLocationUpdates = true
-        #if os(iOS)
-        manager.showsBackgroundLocationIndicator = true
+        #if os(watchOS)
+        // watchOS handles background location via HKWorkoutSession
+        #else
+        if let modes = Bundle.main.infoDictionary?["UIBackgroundModes"] as? [String],
+           modes.contains("location") {
+            manager.allowsBackgroundLocationUpdates = true
+            manager.showsBackgroundLocationIndicator = true
+        }
         #endif
     }
 

--- a/WalkableKit/Sources/WalkableKit/Services/SyncService.swift
+++ b/WalkableKit/Sources/WalkableKit/Services/SyncService.swift
@@ -243,6 +243,8 @@ public final class SyncService: NSObject, ObservableObject {
         } else {
             WCSession.default.transferUserInfo(message)
         }
+        // Also store as applicationContext — always delivered when companion app opens
+        try? WCSession.default.updateApplicationContext(message)
     }
 
     // MARK: - Watch-Created Route Sync (Watch → Phone)
@@ -427,6 +429,15 @@ extension SyncService: @preconcurrency WCSessionDelegate {
             }
             Task { @MainActor in
                 allRoutesSyncReceived.send(payloads)
+            }
+        }
+
+        // Handle session sync via applicationContext fallback
+        if let sessionDict = applicationContext["sessionSync"] as? [String: Any],
+           let data = try? JSONSerialization.data(withJSONObject: sessionDict),
+           let payload = try? { let d = JSONDecoder(); d.dateDecodingStrategy = .iso8601; return d }().decode(SessionSyncPayload.self, from: data) {
+            Task { @MainActor in
+                sessionSyncReceived.send(payload)
             }
         }
     }

--- a/WalkableKit/Sources/WalkableKit/Services/SyncService.swift
+++ b/WalkableKit/Sources/WalkableKit/Services/SyncService.swift
@@ -229,10 +229,20 @@ public final class SyncService: NSObject, ObservableObject {
     // MARK: - Send Walk Session to Phone (from Watch)
 
     public func syncWalkSession(_ payload: SessionSyncPayload) {
-        guard let data = try? JSONEncoder().encode(payload),
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        guard let data = try? encoder.encode(payload),
               let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
 
-        WCSession.default.transferUserInfo(["sessionSync": dict])
+        let message = ["sessionSync": dict]
+        // Try immediate delivery first, fall back to queued transfer
+        if WCSession.default.isReachable {
+            WCSession.default.sendMessage(message, replyHandler: nil) { _ in
+                WCSession.default.transferUserInfo(message)
+            }
+        } else {
+            WCSession.default.transferUserInfo(message)
+        }
     }
 
     // MARK: - Watch-Created Route Sync (Watch → Phone)
@@ -345,7 +355,7 @@ extension SyncService: @preconcurrency WCSessionDelegate {
 
         if let sessionDict = userInfo["sessionSync"] as? [String: Any],
            let data = try? JSONSerialization.data(withJSONObject: sessionDict),
-           let payload = try? JSONDecoder().decode(SessionSyncPayload.self, from: data) {
+           let payload = try? { let d = JSONDecoder(); d.dateDecodingStrategy = .iso8601; return d }().decode(SessionSyncPayload.self, from: data) {
             Task { @MainActor in
                 sessionSyncReceived.send(payload)
             }
@@ -379,6 +389,15 @@ extension SyncService: @preconcurrency WCSessionDelegate {
     }
 
     public nonisolated func session(_ session: WCSession, didReceiveMessage message: [String: Any]) {
+        // Handle session sync via sendMessage
+        if let sessionDict = message["sessionSync"] as? [String: Any],
+           let data = try? JSONSerialization.data(withJSONObject: sessionDict),
+           let payload = try? { let d = JSONDecoder(); d.dateDecodingStrategy = .iso8601; return d }().decode(SessionSyncPayload.self, from: data) {
+            Task { @MainActor in
+                sessionSyncReceived.send(payload)
+            }
+        }
+
         if let routeDict = message["startWalkOnWatch"] as? [String: Any],
            let data = try? JSONSerialization.data(withJSONObject: routeDict),
            let payload = try? JSONDecoder().decode(SyncPayload.self, from: data) {

--- a/WalkableWatch/ViewModels/WatchWalkViewModel.swift
+++ b/WalkableWatch/ViewModels/WatchWalkViewModel.swift
@@ -18,6 +18,8 @@ final class WatchWalkViewModel {
     var currentWaypointIndex = 0
     var visitedWaypointIndices: Set<Int> = []
     var loopCompleted = false
+    var showArrivalBanner = false
+    var arrivedWaypointName: String?
 
     var currentLocation: CLLocationCoordinate2D?
     var currentHeading: Double = 0
@@ -255,10 +257,28 @@ final class WatchWalkViewModel {
 
         if index >= route.waypoints.count {
             loopCompleted = true
+            // Triple haptic for loop complete
             WKInterfaceDevice.current().play(.notification)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                WKInterfaceDevice.current().play(.notification)
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                WKInterfaceDevice.current().play(.notification)
+            }
             return
         }
 
+        // Show waypoint arrival banner
+        let wp = route.sortedWaypoints[index]
+        arrivedWaypointName = wp.label ?? "Waypoint \(index + 1)"
+        showArrivalBanner = true
+        // Double haptic for waypoint arrival
         WKInterfaceDevice.current().play(.success)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            WKInterfaceDevice.current().play(.success)
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
+            self?.showArrivalBanner = false
+        }
     }
 }

--- a/WalkableWatch/ViewModels/WatchWalkViewModel.swift
+++ b/WalkableWatch/ViewModels/WatchWalkViewModel.swift
@@ -24,7 +24,6 @@ final class WatchWalkViewModel {
     var mapCameraPosition: MapCameraPosition = .automatic
     var hasZoomedIn = false
 
-    private var timer: Timer?
     private var startTime = Date()
     private var pausedDuration: TimeInterval = 0
     private var pauseStartTime: Date?
@@ -106,6 +105,11 @@ final class WatchWalkViewModel {
                 self.gpsLocations.append(location)
                 self.healthService.addRouteLocation(location)
 
+                // Update elapsed time from location callback (no Timer needed)
+                if !self.isPaused {
+                    self.elapsedTime = Date().timeIntervalSince(self.startTime) - self.pausedDuration
+                }
+
                 // Track polyline progress for correct split on shared streets.
                 // Cap advancement to 5 segments per update to avoid jumping ahead
                 // when outbound and return legs share a street.
@@ -159,13 +163,8 @@ final class WatchWalkViewModel {
             }
         }
 
-        let walkStart = startTime
-        timer = Timer.scheduledTimer(withTimeInterval: 5, repeats: true) { [weak self] _ in
-            Task { @MainActor in
-                guard let self, !self.isPaused else { return }
-                self.elapsedTime = Date().timeIntervalSince(walkStart) - self.pausedDuration
-            }
-        }
+        // No Timer — elapsedTime updates from location callbacks instead.
+        // Timers keep the run loop active and prevent AOD.
     }
 
     func pauseWalk() {
@@ -188,7 +187,6 @@ final class WatchWalkViewModel {
     }
 
     func endWalk() async {
-        timer?.invalidate()
         locationService.stopTracking()
         locationService.stopHeadingUpdates()
         locationService.clearWaypointMonitoring()

--- a/WalkableWatch/ViewModels/WatchWalkViewModel.swift
+++ b/WalkableWatch/ViewModels/WatchWalkViewModel.swift
@@ -66,6 +66,14 @@ final class WatchWalkViewModel {
         return elapsedTime / (distanceWalked / 1000)
     }
 
+    var heartRate: Double {
+        healthService.heartRate
+    }
+
+    /// For Text(date, style: .timer) — system-rendered, AOD-compatible.
+    /// Stored, not computed, to avoid fighting with the .timer style's own ticking.
+    var timerStartDate: Date = .now
+
     /// Relative bearing: subtract device heading from absolute bearing to get arrow direction.
     var relativeArrowAngle: Double {
         guard let bearing = bearingToNextWaypoint else { return 0 }
@@ -74,6 +82,7 @@ final class WatchWalkViewModel {
 
     func startWalk() async {
         startTime = Date()
+        timerStartDate = startTime
         var coords = route.sortedWaypoints.map { $0.coordinate }
         if let first = coords.first { coords.append(first) }
         locationService.monitorWaypoints(coords)
@@ -151,7 +160,7 @@ final class WatchWalkViewModel {
         }
 
         let walkStart = startTime
-        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
+        timer = Timer.scheduledTimer(withTimeInterval: 5, repeats: true) { [weak self] _ in
             Task { @MainActor in
                 guard let self, !self.isPaused else { return }
                 self.elapsedTime = Date().timeIntervalSince(walkStart) - self.pausedDuration
@@ -162,6 +171,8 @@ final class WatchWalkViewModel {
     func pauseWalk() {
         isPaused = true
         pauseStartTime = Date()
+        // Freeze timer display
+        timerStartDate = .distantFuture
         WKInterfaceDevice.current().play(.stop)
     }
 
@@ -171,6 +182,8 @@ final class WatchWalkViewModel {
             pauseStartTime = nil
         }
         isPaused = false
+        // Resume timer display: set start date accounting for paused duration
+        timerStartDate = startTime.addingTimeInterval(pausedDuration)
         WKInterfaceDevice.current().play(.start)
     }
 

--- a/WalkableWatch/Views/WalkControlsView.swift
+++ b/WalkableWatch/Views/WalkControlsView.swift
@@ -1,10 +1,15 @@
 import SwiftUI
+import WatchKit
 import WalkableKit
 
 struct WalkControlsView: View {
+    let timerStartDate: Date
     let elapsedTime: TimeInterval
     let distance: Double
     let pace: Double
+    let heartRate: Double
+    let currentWaypointIndex: Int
+    let totalWaypoints: Int
     let isPaused: Bool
     let loopCompleted: Bool
     let onPause: () -> Void
@@ -13,9 +18,20 @@ struct WalkControlsView: View {
 
     var body: some View {
         VStack(spacing: 12) {
-            Text(elapsedTime.formattedDuration)
-                .font(.system(size: 40, weight: .bold, design: .rounded))
-                .monospacedDigit()
+            if isPaused {
+                let mins = Int(elapsedTime) / 60
+                let secs = Int(elapsedTime) % 60
+                Text(String(format: "%d:%02d", mins, secs))
+                    .font(.system(size: 40, weight: .bold, design: .rounded))
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+            } else {
+                Text(timerStartDate, style: .timer)
+                    .font(.system(size: 40, weight: .bold, design: .rounded))
+                    .monospacedDigit()
+                    .minimumScaleFactor(0.5)
+                    .lineLimit(1)
+            }
 
             HStack(spacing: 16) {
                 VStack {
@@ -32,6 +48,27 @@ struct WalkControlsView: View {
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                 }
+                VStack {
+                    HStack(spacing: 2) {
+                        Image(systemName: "heart.fill")
+                            .font(.caption2)
+                            .foregroundStyle(.red)
+                        Text(heartRate > 0 ? String(format: "%.0f", heartRate) : "--")
+                            .font(.headline.monospacedDigit())
+                    }
+                    Text("bpm")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            HStack(spacing: 4) {
+                Image(systemName: "mappin.circle.fill")
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+                Text("\(currentWaypointIndex)/\(totalWaypoints)")
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
             }
 
             if loopCompleted {
@@ -42,7 +79,10 @@ struct WalkControlsView: View {
 
             HStack(spacing: 12) {
                 if !loopCompleted {
-                    Button(action: isPaused ? onResume : onPause) {
+                    Button {
+                        WKInterfaceDevice.current().play(isPaused ? .start : .stop)
+                        if isPaused { onResume() } else { onPause() }
+                    } label: {
                         Image(systemName: isPaused ? "play.fill" : "pause.fill")
                             .font(.title3)
                             .frame(width: 50, height: 50)
@@ -50,7 +90,10 @@ struct WalkControlsView: View {
                     .tint(isPaused ? .green : .yellow)
                 }
 
-                Button(action: onEnd) {
+                Button {
+                    WKInterfaceDevice.current().play(.notification)
+                    onEnd()
+                } label: {
                     Image(systemName: loopCompleted ? "checkmark" : "stop.fill")
                         .font(.title3)
                         .frame(width: 50, height: 50)

--- a/WalkableWatch/Views/WalkControlsView.swift
+++ b/WalkableWatch/Views/WalkControlsView.swift
@@ -27,10 +27,8 @@ struct WalkControlsView: View {
                     .foregroundStyle(.secondary)
             } else {
                 Text(timerStartDate, style: .timer)
-                    .font(.system(size: 40, weight: .bold, design: .rounded))
+                    .font(.system(size: 32, weight: .bold, design: .rounded))
                     .monospacedDigit()
-                    .minimumScaleFactor(0.5)
-                    .lineLimit(1)
             }
 
             HStack(spacing: 16) {

--- a/WalkableWatch/Views/WalkControlsView.swift
+++ b/WalkableWatch/Views/WalkControlsView.swift
@@ -15,16 +15,19 @@ struct WalkControlsView: View {
     let onPause: () -> Void
     let onResume: () -> Void
     let onEnd: () -> Void
+    @Environment(\.isLuminanceReduced) private var isAOD
 
     var body: some View {
         VStack(spacing: 12) {
-            if isPaused {
+            if isPaused || isAOD {
+                // Static short format for paused and AOD
+                // (.timer style renders "60 minutes, 40 seconds" in AOD which truncates)
                 let mins = Int(elapsedTime) / 60
                 let secs = Int(elapsedTime) % 60
                 Text(String(format: "%d:%02d", mins, secs))
                     .font(.system(size: 40, weight: .bold, design: .rounded))
                     .monospacedDigit()
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(isPaused ? .secondary : .primary)
             } else {
                 Text(timerStartDate, style: .timer)
                     .font(.system(size: 32, weight: .bold, design: .rounded))

--- a/WalkableWatch/Views/WalkControlsView.swift
+++ b/WalkableWatch/Views/WalkControlsView.swift
@@ -16,15 +16,11 @@ struct WalkControlsView: View {
             Text(elapsedTime.formattedDuration)
                 .font(.system(size: 40, weight: .bold, design: .rounded))
                 .monospacedDigit()
-                .contentTransition(.numericText())
-                .animation(.smooth, value: elapsedTime)
 
             HStack(spacing: 16) {
                 VStack {
                     Text(String(format: "%.2f", distance / 1000))
                         .font(.headline.monospacedDigit())
-                        .contentTransition(.numericText())
-                        .animation(.smooth, value: distance)
                     Text("km")
                         .font(.caption2)
                         .foregroundStyle(.secondary)
@@ -32,8 +28,6 @@ struct WalkControlsView: View {
                 VStack {
                     Text(pace.formattedPaceShort)
                         .font(.headline.monospacedDigit())
-                        .contentTransition(.numericText())
-                        .animation(.smooth, value: pace)
                     Text("pace")
                         .font(.caption2)
                         .foregroundStyle(.secondary)

--- a/WalkableWatch/Views/WalkTabView.swift
+++ b/WalkableWatch/Views/WalkTabView.swift
@@ -8,6 +8,7 @@ struct WalkTabView: View {
 
     @State private var viewModel: WatchWalkViewModel
     @State private var selectedTab = 1
+    @Environment(\.isLuminanceReduced) private var isAOD
 
     init(route: Route, onEnd: @escaping () -> Void) {
         self.route = route
@@ -27,9 +28,13 @@ struct WalkTabView: View {
             TabView(selection: $selectedTab) {
                 // View 1: Controls
                 WalkControlsView(
+                    timerStartDate: viewModel.timerStartDate,
                     elapsedTime: viewModel.elapsedTime,
                     distance: viewModel.distanceWalked,
                     pace: viewModel.currentPace,
+                    heartRate: viewModel.heartRate,
+                    currentWaypointIndex: viewModel.currentWaypointIndex,
+                    totalWaypoints: viewModel.route.waypoints.count,
                     isPaused: viewModel.isPaused,
                     loopCompleted: viewModel.loopCompleted,
                     onPause: { viewModel.pauseWalk() },
@@ -45,6 +50,7 @@ struct WalkTabView: View {
                     currentWaypointIndex: viewModel.currentWaypointIndex,
                     visitedWaypointIndices: viewModel.visitedWaypointIndices,
                     polylineSearchFromIndex: viewModel.lastPolylineSegmentIndex,
+                    timerStartDate: viewModel.timerStartDate,
                     distanceWalked: viewModel.distanceWalked,
                     elapsedTime: viewModel.elapsedTime,
                     distanceToNext: viewModel.distanceToNextWaypoint,
@@ -69,6 +75,11 @@ struct WalkTabView: View {
                     .tag(3)
             }
             .tabViewStyle(.page)
+            .opacity(isAOD ? 0.6 : 1.0)
+            .allowsHitTesting(!isAOD)
+            .onChange(of: isAOD) {
+                if isAOD { selectedTab = 0 }
+            }
             .task {
                 await viewModel.startWalk()
             }

--- a/WalkableWatch/Views/WalkTabView.swift
+++ b/WalkableWatch/Views/WalkTabView.swift
@@ -25,6 +25,7 @@ struct WalkTabView: View {
                 onDismiss: onEnd
             )
         } else {
+            ZStack {
             TabView(selection: $selectedTab) {
                 // View 1: Controls
                 WalkControlsView(
@@ -47,6 +48,7 @@ struct WalkTabView: View {
                 WatchMapView(
                     route: route,
                     currentLocation: viewModel.currentLocation,
+                    currentHeading: viewModel.currentHeading,
                     currentWaypointIndex: viewModel.currentWaypointIndex,
                     visitedWaypointIndices: viewModel.visitedWaypointIndices,
                     polylineSearchFromIndex: viewModel.lastPolylineSegmentIndex,
@@ -83,6 +85,26 @@ struct WalkTabView: View {
             .task {
                 await viewModel.startWalk()
             }
+
+            // Waypoint arrival banner overlay
+            if viewModel.showArrivalBanner, let name = viewModel.arrivedWaypointName {
+                VStack {
+                    HStack(spacing: 6) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                        Text(name)
+                            .font(.headline)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(.green.opacity(0.2), in: Capsule())
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                .padding(.top, 8)
+                .transition(.move(edge: .top).combined(with: .opacity))
+                .animation(.spring(duration: 0.4), value: viewModel.showArrivalBanner)
+            }
+            } // ZStack
         }
     }
 }

--- a/WalkableWatch/Views/WatchMapView.swift
+++ b/WalkableWatch/Views/WatchMapView.swift
@@ -61,8 +61,6 @@ struct WatchMapView: View {
                         .foregroundStyle(.secondary)
                     Text(distanceWalked.formattedDistance)
                         .font(.system(size: 12, weight: .semibold, design: .rounded))
-                        .contentTransition(.numericText())
-                        .animation(.smooth, value: distanceWalked)
                 }
                 Spacer()
                 VStack(spacing: 0) {
@@ -71,8 +69,6 @@ struct WatchMapView: View {
                         .foregroundStyle(.secondary)
                     Text(elapsedTime.formattedDuration)
                         .font(.system(size: 12, weight: .semibold, design: .rounded))
-                        .contentTransition(.numericText())
-                        .animation(.smooth, value: elapsedTime)
                 }
                 Spacer()
                 VStack(spacing: 0) {

--- a/WalkableWatch/Views/WatchMapView.swift
+++ b/WalkableWatch/Views/WatchMapView.swift
@@ -8,6 +8,7 @@ struct WatchMapView: View {
     let currentWaypointIndex: Int
     let visitedWaypointIndices: Set<Int>
     let polylineSearchFromIndex: Int
+    let timerStartDate: Date
     let distanceWalked: Double
     let elapsedTime: TimeInterval
     let distanceToNext: Double?
@@ -67,7 +68,7 @@ struct WatchMapView: View {
                     Text("TIME")
                         .font(.system(size: 8))
                         .foregroundStyle(.secondary)
-                    Text(elapsedTime.formattedDuration)
+                    Text(timerStartDate, style: .timer)
                         .font(.system(size: 12, weight: .semibold, design: .rounded))
                 }
                 Spacer()

--- a/WalkableWatch/Views/WatchMapView.swift
+++ b/WalkableWatch/Views/WatchMapView.swift
@@ -5,6 +5,7 @@ import WalkableKit
 struct WatchMapView: View {
     let route: Route
     let currentLocation: CLLocationCoordinate2D?
+    let currentHeading: Double
     let currentWaypointIndex: Int
     let visitedWaypointIndices: Set<Int>
     let polylineSearchFromIndex: Int
@@ -13,6 +14,7 @@ struct WatchMapView: View {
     let elapsedTime: TimeInterval
     let distanceToNext: Double?
     @Binding var cameraPosition: MapCameraPosition
+    @Environment(\.isLuminanceReduced) private var isAOD
 
     var body: some View {
         VStack(spacing: 0) {
@@ -45,14 +47,21 @@ struct WatchMapView: View {
 
                 if let loc = currentLocation {
                     Annotation("", coordinate: loc) {
-                        Circle()
-                            .fill(.green)
-                            .frame(width: 12)
-                            .overlay(Circle().stroke(.white, lineWidth: 2))
+                        Image(systemName: "location.north.fill")
+                            .font(.system(size: 16))
+                            .foregroundStyle(.blue)
+                            .rotationEffect(.degrees(currentHeading))
+                            .shadow(color: .black.opacity(0.3), radius: 2)
                     }
                 }
             }
             .mapStyle(.standard(elevation: .flat, pointsOfInterest: .excludingAll))
+            .onChange(of: isAOD) {
+                // Re-center map when wrist comes back up or goes down
+                if let loc = currentLocation {
+                    cameraPosition = .camera(MapCamera(centerCoordinate: loc, distance: 800))
+                }
+            }
 
             // Stats bar - outside the map so swiping here switches pages
             HStack {

--- a/WalkableWidgets/WalkableLiveActivity.swift
+++ b/WalkableWidgets/WalkableLiveActivity.swift
@@ -18,10 +18,13 @@ struct WalkableLiveActivity: Widget {
                     HStack(spacing: 12) {
                         Label(String(format: "%.2f km", context.state.distance / 1000), systemImage: "ruler")
                         if context.state.isPaused {
-                            Text("PAUSED")
+                            Label("PAUSED", systemImage: "pause.fill")
                                 .foregroundStyle(.orange)
                         } else {
-                            Text(context.state.timerStart, style: .timer)
+                            let mins = Int(context.state.elapsedTime) / 60
+                            let secs = Int(context.state.elapsedTime) % 60
+                            Label(String(format: "%d:%02d", mins, secs), systemImage: "clock")
+                                .contentTransition(.numericText())
                         }
                     }
                     .font(.caption)
@@ -30,51 +33,104 @@ struct WalkableLiveActivity: Widget {
 
                 Spacer()
 
-                Text("\(context.state.currentWaypointIndex)/\(context.state.totalWaypoints)")
-                    .font(.title3.weight(.bold).monospacedDigit())
-                    .foregroundStyle(.blue)
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text("\(context.state.currentWaypointIndex)/\(context.state.totalWaypoints)")
+                        .font(.title3.weight(.bold).monospacedDigit())
+                        .foregroundStyle(.blue)
+                    if let dist = context.state.nextWaypointDistance {
+                        Text(String(format: "%.0fm to next", dist))
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
             }
             .padding()
         } dynamicIsland: { context in
             DynamicIsland {
-                DynamicIslandExpandedRegion(.leading) {
-                    HStack(alignment: .firstTextBaseline, spacing: 2) {
-                        Text(String(format: "%.2f", context.state.distance / 1000))
-                            .font(.system(size: 22, weight: .bold, design: .rounded))
-                        Text("km")
-                            .font(.system(size: 11))
-                            .foregroundStyle(.secondary)
-                    }
-                }
-                DynamicIslandExpandedRegion(.trailing) {
-                    if context.state.isPaused {
-                        Text("PAUSED")
-                            .font(.system(size: 18, weight: .bold, design: .rounded))
-                            .foregroundStyle(.orange)
-                    } else {
-                        Text(context.state.timerStart, style: .timer)
-                            .font(.system(size: 22, weight: .bold, design: .rounded))
-                            .monospacedDigit()
-                            .multilineTextAlignment(.trailing)
-                    }
-                }
                 DynamicIslandExpandedRegion(.bottom) {
-                    // Empty bottom pushes leading/trailing content to center vertically
-                    Spacer(minLength: 0)
+                    HStack(alignment: .center, spacing: 8) {
+                        Button(intent: EndWalkIntent()) {
+                            Image(systemName: "stop.fill")
+                                .font(.system(size: 16, weight: .bold))
+                                .foregroundStyle(.black)
+                                .frame(width: 36, height: 36)
+                                .background(.red, in: Circle())
+                        }
+                        .buttonStyle(.plain)
+                        .offset(y: -6)
+
+                        // Distance + waypoint counter
+                        VStack(alignment: .center, spacing: 2) {
+                            HStack(alignment: .firstTextBaseline, spacing: 2) {
+                                Text(String(format: "%.2f", context.state.distance / 1000))
+                                    .font(.system(size: 24, weight: .bold, design: .rounded))
+                                Text("km")
+                                    .font(.system(size: 12))
+                                    .foregroundStyle(.secondary)
+                            }
+                            .fixedSize()
+                            Label("\(context.state.currentWaypointIndex)/\(context.state.totalWaypoints)", systemImage: "mappin.circle.fill")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                                .fixedSize()
+                        }
+                        .frame(maxWidth: .infinity)
+
+                        RoundedRectangle(cornerRadius: 1)
+                            .fill(.quaternary)
+                            .frame(width: 2, height: 36)
+
+                        // Timer + distance to next
+                        VStack(alignment: .center, spacing: 2) {
+                            if context.state.isPaused {
+                                let mins = Int(context.state.elapsedTime) / 60
+                                let secs = Int(context.state.elapsedTime) % 60
+                                Text(String(format: "%d:%02d", mins, secs))
+                                    .font(.system(size: 24, weight: .bold, design: .rounded))
+                                    .monospacedDigit()
+                                    .foregroundStyle(.secondary)
+                            } else {
+                                Text(context.state.timerStart, style: .timer)
+                                    .font(.system(size: 24, weight: .bold, design: .rounded))
+                                    .monospacedDigit()
+                                    .multilineTextAlignment(.center)
+                                    .frame(maxWidth: .infinity)
+                            }
+                            if context.state.isPaused {
+                                Text("PAUSED")
+                                    .font(.caption2.weight(.light))
+                                    .foregroundStyle(.orange)
+                            } else if let dist = context.state.nextWaypointDistance {
+                                Label(String(format: "%.0fm", dist), systemImage: "arrow.forward")
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                            } else {
+                                Label("--", systemImage: "arrow.forward")
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .frame(maxWidth: .infinity)
+
+                        Button(intent: TogglePauseIntent()) {
+                            Image(systemName: context.state.isPaused ? "play.fill" : "pause.fill")
+                                .font(.system(size: 16, weight: .bold))
+                                .foregroundStyle(.black)
+                                .frame(width: 36, height: 36)
+                                .background(context.state.isPaused ? Color.orange : Color.blue, in: Circle())
+                        }
+                        .buttonStyle(.plain)
+                        .offset(y: -6)
+                    }
+                    .padding(.horizontal, 4)
                 }
             } compactLeading: {
                 Image(systemName: context.state.isPaused ? "pause.fill" : "figure.walk")
                     .foregroundStyle(context.state.isPaused ? .orange : .blue)
             } compactTrailing: {
-                if context.state.isPaused {
-                    Text("||")
-                        .font(.caption.bold())
-                        .foregroundStyle(.orange)
-                } else {
-                    Text(context.state.timerStart, style: .timer)
-                        .font(.caption.monospacedDigit())
-                        .foregroundStyle(.blue)
-                }
+                Text(String(format: "%.1fkm", context.state.distance / 1000))
+                    .font(.caption2.weight(.semibold).monospacedDigit())
+                    .foregroundStyle(context.state.isPaused ? .orange : .blue)
             } minimal: {
                 Image(systemName: context.state.isPaused ? "pause.fill" : "figure.walk")
                     .foregroundStyle(context.state.isPaused ? .orange : .blue)

--- a/project.yml
+++ b/project.yml
@@ -37,13 +37,17 @@ targets:
         embed: true
       - target: WalkableWatch
         embed: true
+    info:
+      path: WalkableApp/Info.plist
+      properties:
+        UIBackgroundModes:
+          - location
     settings:
       GENERATE_INFOPLIST_FILE: true
       CODE_SIGN_STYLE: Automatic
       ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
       INFOPLIST_KEY_UILaunchScreen_Generation: true
       INFOPLIST_KEY_CFBundleDisplayName: Walkable
-      INFOPLIST_KEY_UIBackgroundModes: location
       CFBundleURLTypes:
         - CFBundleURLSchemes:
             - walkable

--- a/project.yml
+++ b/project.yml
@@ -44,6 +44,9 @@ targets:
       INFOPLIST_KEY_UILaunchScreen_Generation: true
       INFOPLIST_KEY_CFBundleDisplayName: Walkable
       INFOPLIST_KEY_UIBackgroundModes: location
+      CFBundleURLTypes:
+        - CFBundleURLSchemes:
+            - walkable
       INFOPLIST_KEY_NSSupportsLiveActivities: true
       INFOPLIST_KEY_NSLocationWhenInUseUsageDescription: "Walkable needs your location to track walks and show your position on the map."
       INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription: "Walkable needs background location access to track your walks."


### PR DESCRIPTION
## Summary
- Redesigned expanded DI: stop/play-pause buttons on sides, km|timer centered with waypoint counter + distance to next below
- Compact DI uses minimal width (icon + distance, no timer)
- Play/pause and stop buttons work via LiveActivityIntents without opening the app
- Timer uses .timer style for background-safe ticking
- Fixed UIBackgroundModes plist (was string, now proper array) so background location stays alive past 30s
- Lock screen widget shows waypoint progress
- Pin mode hint text passes touches through to map

## Test plan
- [ ] Start walk, background app, verify DI timer ticks and distance updates past 30s
- [ ] Tap pause/play on DI without app opening
- [ ] Tap stop on DI, verify walk ends and saves
- [ ] Verify compact DI is narrow, not full width
- [ ] Verify expanded DI layout matches on pause vs play states