### PR TITLE
fix: watch walk polish, HealthKit import, map pill, AOD fixes

### DIFF
--- a/Walkable.xcodeproj/project.pbxproj
+++ b/Walkable.xcodeproj/project.pbxproj
@@ -154,10 +154,11 @@
 		44DBE628CD2816AF0CC6C0E3 /* RouteListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteListView.swift; sourceTree = "<group>"; };
 		4555554BF8D7071BD426467B /* SaveRouteSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveRouteSheet.swift; sourceTree = "<group>"; };
 		4A200AD9B414882AC6C7C572 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		51D80C129C05029BAD7DE958 /* WalkableApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WalkableApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		5515782EF765667BB5836D12 /* WalkableWidgets.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = WalkableWidgets.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		51D80C129C05029BAD7DE958 /* WalkableApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = WalkableApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		5515782EF765667BB5836D12 /* WalkableWidgets.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = WalkableWidgets.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		57B9A25E290E6711909B627B /* WalkableKit */ = {isa = PBXFileReference; lastKnownFileType = folder; path = WalkableKit; sourceTree = SOURCE_ROOT; };
 		57F061AAADC8839C2E49EE10 /* WalkTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkTabView.swift; sourceTree = "<group>"; };
+		59A20463D956D4332A76E146 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		5DB7618EACDEED770EA1628E /* WalkableLiveActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkableLiveActivity.swift; sourceTree = "<group>"; };
 		65910331A837344A3DF7308C /* WalkableWidgetsBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkableWidgetsBundle.swift; sourceTree = "<group>"; };
 		6765B12731821E706EA6FBEC /* PolylineSplitterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolylineSplitterTests.swift; sourceTree = "<group>"; };
@@ -426,6 +427,7 @@
 			children = (
 				2D67A9E3E74F2085B5D00F5B /* Assets.xcassets */,
 				307090577F05AA73E61C1159 /* ContentView.swift */,
+				59A20463D956D4332A76E146 /* Info.plist */,
 				40CDD85F619FEE037E736AEB /* WalkableApp.entitlements */,
 				856C3414EF05FE64556D6E09 /* WalkableApp.swift */,
 				1CCD1316C1DE77671B688B3B /* ViewModels */,
@@ -763,7 +765,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = HYM2LV4SPQ;
 				INFOPLIST_FILE = WalkableWidgets/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Walkable;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -815,18 +816,18 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CFBundleURLTypes = "[[\"CFBundleURLSchemes\": [\"walkable\"]]]";
 				CODE_SIGN_ENTITLEMENTS = WalkableApp/WalkableApp.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = HYM2LV4SPQ;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = WalkableApp/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Walkable;
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Walkable reads your health data to show fitness stats.";
 				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "Walkable saves your walking workouts to Apple Health.";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "Walkable needs background location access to track your walks.";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Walkable needs your location to track walks and show your position on the map.";
 				INFOPLIST_KEY_NSSupportsLiveActivities = YES;
-				INFOPLIST_KEY_UIBackgroundModes = location;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -842,18 +843,18 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CFBundleURLTypes = "[[\"CFBundleURLSchemes\": [\"walkable\"]]]";
 				CODE_SIGN_ENTITLEMENTS = WalkableApp/WalkableApp.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = HYM2LV4SPQ;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = WalkableApp/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Walkable;
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Walkable reads your health data to show fitness stats.";
 				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "Walkable saves your walking workouts to Apple Health.";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "Walkable needs background location access to track your walks.";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Walkable needs your location to track walks and show your position on the map.";
 				INFOPLIST_KEY_NSSupportsLiveActivities = YES;
-				INFOPLIST_KEY_UIBackgroundModes = location;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -869,7 +870,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = HYM2LV4SPQ;
 				INFOPLIST_FILE = WalkableWidgets/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Walkable;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Walkable.xcodeproj/xcshareddata/xcschemes/WalkableWatch.xcscheme
+++ b/Walkable.xcodeproj/xcshareddata/xcschemes/WalkableWatch.xcscheme
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1600"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES"
-      runPostActionsOnFailure = "NO">
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -27,8 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/WalkableApp/ContentView.swift
+++ b/WalkableApp/ContentView.swift
@@ -8,6 +8,7 @@ struct ContentView: View {
     @State private var isReady = false
     @Environment(\.modelContext) private var modelContext
     @Query private var allRoutes: [Route]
+    @Query private var allSessions: [WalkSession]
 
     var body: some View {
         ZStack {
@@ -85,6 +86,8 @@ struct ContentView: View {
             DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                 SyncService.shared.syncAllRoutes(allRoutes)
             }
+            // Import any Walkable workouts from HealthKit that aren't in our database
+            Task { await importMissingHealthKitWorkouts() }
         }
         .onReceive(SyncService.shared.watchBecameReachable) {
             SyncService.shared.syncAllRoutes(allRoutes)
@@ -144,6 +147,43 @@ struct ContentView: View {
         session.source = payload.source ?? "watch"
 
         modelContext.insert(session)
+        try? modelContext.save()
+    }
+
+    private func importMissingHealthKitWorkouts() async {
+        guard let workouts = try? await HealthService.shared.fetchWalkableWorkouts() else { return }
+
+        let existingDates = Set(allSessions.map { $0.startedAt.timeIntervalSinceReferenceDate })
+
+        for workout in workouts {
+            // Skip if we already have a session that started at the same time (within 5s tolerance)
+            let workoutStart = workout.startDate.timeIntervalSinceReferenceDate
+            let alreadyExists = existingDates.contains { abs($0 - workoutStart) < 5 }
+            guard !alreadyExists else { continue }
+
+            // Find the closest matching route by distance
+            let workoutDistance = workout.totalDistance?.doubleValue(for: .meter()) ?? 0
+            guard let matchingRoute = allRoutes.min(by: { a, b in
+                abs(a.distance - workoutDistance) < abs(b.distance - workoutDistance)
+            }) else { continue }
+
+            let session = WalkSession(route: matchingRoute)
+            session.startedAt = workout.startDate
+            session.completedAt = workout.endDate
+            session.totalDistance = workoutDistance
+            session.totalDuration = workout.duration
+            session.calories = workout.totalEnergyBurned?.doubleValue(for: .kilocalorie()) ?? 0
+            session.source = "healthkit"
+
+            // Try to fetch the GPS route
+            if let locations = try? await HealthService.shared.fetchWorkoutRoute(workout), !locations.isEmpty {
+                let coords = locations.map { CodableCoordinate($0.coordinate) }
+                session.gpsTrackData = try? JSONEncoder().encode(coords)
+            }
+
+            modelContext.insert(session)
+        }
+
         try? modelContext.save()
     }
 }

--- a/WalkableKit/Sources/WalkableKit/Services/HealthService.swift
+++ b/WalkableKit/Sources/WalkableKit/Services/HealthService.swift
@@ -147,6 +147,59 @@ public final class HealthService: NSObject, ObservableObject {
         routeBuilder?.insertRouteData([location]) { _, _ in }
     }
 
+    // MARK: - Query Walkable Workouts from HealthKit
+
+    /// Fetch walking workouts recorded by this app (source = Walkable bundle ID).
+    public func fetchWalkableWorkouts(since date: Date = .distantPast) async throws -> [HKWorkout] {
+        guard HKHealthStore.isHealthDataAvailable() else { return [] }
+
+        let walkPredicate = HKQuery.predicateForWorkouts(with: .walking)
+        let datePredicate = HKQuery.predicateForSamples(withStart: date, end: nil)
+        let sourcePredicate = HKQuery.predicateForObjects(from: .default())
+        let compound = NSCompoundPredicate(andPredicateWithSubpredicates: [walkPredicate, datePredicate, sourcePredicate])
+
+        return try await withCheckedThrowingContinuation { continuation in
+            let query = HKSampleQuery(
+                sampleType: .workoutType(),
+                predicate: compound,
+                limit: HKObjectQueryNoLimit,
+                sortDescriptors: [NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: false)]
+            ) { _, results, error in
+                if let error { continuation.resume(throwing: error); return }
+                continuation.resume(returning: (results as? [HKWorkout]) ?? [])
+            }
+            store.execute(query)
+        }
+    }
+
+    /// Fetch the GPS route for a specific workout.
+    public func fetchWorkoutRoute(_ workout: HKWorkout) async throws -> [CLLocation] {
+        let routes = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[HKWorkoutRoute], Error>) in
+            let query = HKAnchoredObjectQuery(
+                type: HKSeriesType.workoutRoute(),
+                predicate: HKQuery.predicateForObjects(from: workout),
+                anchor: nil,
+                limit: HKObjectQueryNoLimit
+            ) { _, samples, _, _, error in
+                if let error { continuation.resume(throwing: error); return }
+                continuation.resume(returning: (samples as? [HKWorkoutRoute]) ?? [])
+            }
+            store.execute(query)
+        }
+
+        guard let route = routes.first else { return [] }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            var locations = [CLLocation]()
+            let routeQuery = HKWorkoutRouteQuery(route: route) { _, batch, done, error in
+                if let error { continuation.resume(throwing: error); return }
+                if let batch { locations.append(contentsOf: batch) }
+                if done { continuation.resume(returning: locations) }
+            }
+            store.execute(routeQuery)
+        }
+    }
+
     // MARK: - Delete Workout
 
     /// Delete a workout from HealthKit by its UUID.

--- a/WalkableWatch/ViewModels/WatchWalkViewModel.swift
+++ b/WalkableWatch/ViewModels/WatchWalkViewModel.swift
@@ -25,6 +25,7 @@ final class WatchWalkViewModel {
     var currentHeading: Double = 0
     var mapCameraPosition: MapCameraPosition = .automatic
     var hasZoomedIn = false
+    var lastManualMapInteraction: Date = .distantPast
 
     private var startTime = Date()
     private var pausedDuration: TimeInterval = 0
@@ -104,6 +105,14 @@ final class WatchWalkViewModel {
                 guard let self else { return }
                 self.currentLocation = location.coordinate
                 self.distanceWalked = self.healthService.distanceWalked ?? 0
+
+                // Auto-re-center map if user hasn't swiped in 10 seconds
+                if self.hasZoomedIn && Date().timeIntervalSince(self.lastManualMapInteraction) > 10 {
+                    self.mapCameraPosition = .camera(MapCamera(
+                        centerCoordinate: location.coordinate,
+                        distance: 800
+                    ))
+                }
                 self.gpsLocations.append(location)
                 self.healthService.addRouteLocation(location)
 

--- a/WalkableWatch/Views/WalkControlsView.swift
+++ b/WalkableWatch/Views/WalkControlsView.swift
@@ -22,8 +22,9 @@ struct WalkControlsView: View {
             if isPaused || isAOD {
                 // Static short format for paused and AOD
                 // (.timer style renders "60 minutes, 40 seconds" in AOD which truncates)
-                let mins = Int(elapsedTime) / 60
-                let secs = Int(elapsedTime) % 60
+                let elapsed = isPaused ? elapsedTime : Date().timeIntervalSince(timerStartDate)
+                let mins = Int(elapsed) / 60
+                let secs = Int(elapsed) % 60
                 Text(String(format: "%d:%02d", mins, secs))
                     .font(.system(size: 40, weight: .bold, design: .rounded))
                     .monospacedDigit()

--- a/WalkableWatch/Views/WalkControlsView.swift
+++ b/WalkableWatch/Views/WalkControlsView.swift
@@ -20,15 +20,19 @@ struct WalkControlsView: View {
     var body: some View {
         VStack(spacing: 12) {
             if isPaused || isAOD {
-                // Static short format for paused and AOD
-                // (.timer style renders "60 minutes, 40 seconds" in AOD which truncates)
-                let elapsed = isPaused ? elapsedTime : Date().timeIntervalSince(timerStartDate)
-                let mins = Int(elapsed) / 60
-                let secs = Int(elapsed) % 60
-                Text(String(format: "%d:%02d", mins, secs))
-                    .font(.system(size: 40, weight: .bold, design: .rounded))
-                    .monospacedDigit()
-                    .foregroundStyle(isPaused ? .secondary : .primary)
+                if isAOD && !isPaused {
+                    Text("-:--")
+                        .font(.system(size: 40, weight: .bold, design: .rounded))
+                        .monospacedDigit()
+                        .foregroundStyle(.secondary)
+                } else {
+                    let mins = Int(elapsedTime) / 60
+                    let secs = Int(elapsedTime) % 60
+                    Text(String(format: "%d:%02d", mins, secs))
+                        .font(.system(size: 40, weight: .bold, design: .rounded))
+                        .monospacedDigit()
+                        .foregroundStyle(.secondary)
+                }
             } else {
                 Text(timerStartDate, style: .timer)
                     .font(.system(size: 32, weight: .bold, design: .rounded))

--- a/WalkableWatch/Views/WalkTabView.swift
+++ b/WalkableWatch/Views/WalkTabView.swift
@@ -59,7 +59,10 @@ struct WalkTabView: View {
                     cameraPosition: Binding(
                         get: { viewModel.mapCameraPosition },
                         set: { viewModel.mapCameraPosition = $0 }
-                    )
+                    ),
+                    onManualMapInteraction: {
+                        viewModel.lastManualMapInteraction = Date()
+                    }
                 )
                 .tag(1)
 

--- a/WalkableWatch/Views/WalkTabView.swift
+++ b/WalkableWatch/Views/WalkTabView.swift
@@ -48,7 +48,6 @@ struct WalkTabView: View {
                 WatchMapView(
                     route: route,
                     currentLocation: viewModel.currentLocation,
-                    currentHeading: viewModel.currentHeading,
                     currentWaypointIndex: viewModel.currentWaypointIndex,
                     visitedWaypointIndices: viewModel.visitedWaypointIndices,
                     polylineSearchFromIndex: viewModel.lastPolylineSegmentIndex,
@@ -82,8 +81,24 @@ struct WalkTabView: View {
             .tabViewStyle(.page)
             .opacity(isAOD ? 0.6 : 1.0)
             .allowsHitTesting(!isAOD)
+            .onChange(of: selectedTab) {
+                // Re-center map when swiping to the map tab
+                if selectedTab == 1, let loc = viewModel.currentLocation {
+                    viewModel.mapCameraPosition = .camera(MapCamera(
+                        centerCoordinate: loc, distance: 800
+                    ))
+                }
+            }
             .onChange(of: isAOD) {
-                if isAOD { selectedTab = 0 }
+                if isAOD {
+                    selectedTab = 0
+                }
+                // Re-center map when waking from AOD or going to sleep
+                if let loc = viewModel.currentLocation {
+                    viewModel.mapCameraPosition = .camera(MapCamera(
+                        centerCoordinate: loc, distance: 800
+                    ))
+                }
             }
             .task {
                 await viewModel.startWalk()

--- a/WalkableWatch/Views/WalkTabView.swift
+++ b/WalkableWatch/Views/WalkTabView.swift
@@ -105,24 +105,24 @@ struct WalkTabView: View {
             }
 
             // Waypoint arrival banner overlay
-            if viewModel.showArrivalBanner, let name = viewModel.arrivedWaypointName {
-                VStack {
-                    HStack(spacing: 6) {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundStyle(.green)
-                        Text(name)
-                            .font(.headline)
-                    }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
-                    .background(.green.opacity(0.2), in: Capsule())
+            VStack {
+                HStack(spacing: 6) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                    Text(viewModel.arrivedWaypointName ?? "")
+                        .font(.headline)
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-                .padding(.top, 8)
-                .transition(.move(edge: .top).combined(with: .opacity))
-                .animation(.spring(duration: 0.4), value: viewModel.showArrivalBanner)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .glassEffect(.regular, in: .capsule)
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            .padding(.top, 8)
+            .opacity(viewModel.showArrivalBanner && !isAOD ? 1 : 0)
+            .animation(.easeInOut(duration: 0.3), value: viewModel.showArrivalBanner)
+            .allowsHitTesting(false)
             } // ZStack
+            .animation(.easeInOut(duration: 0.5), value: viewModel.showArrivalBanner)
         }
     }
 }

--- a/WalkableWatch/Views/WatchMapView.swift
+++ b/WalkableWatch/Views/WatchMapView.swift
@@ -89,14 +89,9 @@ struct WatchMapView: View {
                     .padding(.vertical, 6)
                     .glassEffect(.regular, in: .capsule)
                     .frame(maxWidth: .infinity)
+                    .contentShape(Rectangle().inset(by: -25))
                     .offset(y: 18)
                     .ignoresSafeArea()
-                    .overlay {
-                        // Invisible touch target at the pill's visual position
-                        Color.clear
-                            .contentShape(Rectangle())
-                            .offset(y: 18)
-                    }
                     .contentTransition(.numericText())
                     .animation(.smooth, value: index)
                 }

--- a/WalkableWatch/Views/WatchMapView.swift
+++ b/WalkableWatch/Views/WatchMapView.swift
@@ -89,8 +89,14 @@ struct WatchMapView: View {
                     .padding(.vertical, 6)
                     .glassEffect(.regular, in: .capsule)
                     .frame(maxWidth: .infinity)
-                    .padding(.bottom, 4)
-                    .contentShape(Rectangle())
+                    .offset(y: 18)
+                    .ignoresSafeArea()
+                    .overlay {
+                        // Invisible touch target at the pill's visual position
+                        Color.clear
+                            .contentShape(Rectangle())
+                            .offset(y: 18)
+                    }
                     .contentTransition(.numericText())
                     .animation(.smooth, value: index)
                 }

--- a/WalkableWatch/Views/WatchMapView.swift
+++ b/WalkableWatch/Views/WatchMapView.swift
@@ -5,7 +5,6 @@ import WalkableKit
 struct WatchMapView: View {
     let route: Route
     let currentLocation: CLLocationCoordinate2D?
-    let currentHeading: Double
     let currentWaypointIndex: Int
     let visitedWaypointIndices: Set<Int>
     let polylineSearchFromIndex: Int
@@ -18,7 +17,8 @@ struct WatchMapView: View {
     @Environment(\.isLuminanceReduced) private var isAOD
 
     var body: some View {
-        VStack(spacing: 0) {
+        ZStack(alignment: .bottom) {
+            // Full-screen map
             Map(position: $cameraPosition) {
                 if let coords = route.decodedPolylineCoordinates {
                     if let currentLoc = currentLocation {
@@ -48,11 +48,10 @@ struct WatchMapView: View {
 
                 if let loc = currentLocation {
                     Annotation("", coordinate: loc) {
-                        Image(systemName: "location.north.fill")
-                            .font(.system(size: 16))
-                            .foregroundStyle(.blue)
-                            .rotationEffect(.degrees(currentHeading))
-                            .shadow(color: .black.opacity(0.3), radius: 2)
+                        Circle()
+                            .fill(.blue)
+                            .frame(width: 12)
+                            .overlay(Circle().stroke(.white, lineWidth: 2))
                     }
                 }
             }
@@ -61,42 +60,40 @@ struct WatchMapView: View {
                 onManualMapInteraction()
             }
             .onChange(of: isAOD) {
-                // Re-center map when wrist comes back up or goes down
                 if let loc = currentLocation {
                     cameraPosition = .camera(MapCamera(centerCoordinate: loc, distance: 800))
                 }
             }
 
-            // Stats bar - outside the map so swiping here switches pages
-            HStack {
-                VStack(spacing: 0) {
-                    Text("DIST")
-                        .font(.system(size: 8))
-                        .foregroundStyle(.secondary)
-                    Text(distanceWalked.formattedDistance)
-                        .font(.system(size: 12, weight: .semibold, design: .rounded))
+            // Glass stats bar overlaid on map
+                TimelineView(.periodic(from: .now, by: 3)) { timeline in
+                    let index = Int(timeline.date.timeIntervalSinceReferenceDate / 3) % 3
+                    HStack(spacing: 4) {
+                        Group {
+                            switch index {
+                            case 0:
+                                Image(systemName: "ruler")
+                                Text(distanceWalked.formattedDistance)
+                            case 1:
+                                Image(systemName: "clock")
+                                Text(timerStartDate, style: .timer)
+                            default:
+                                Image(systemName: "mappin")
+                                Text(distanceToNext?.formattedDistance ?? "--")
+                                    .foregroundStyle(.orange)
+                            }
+                        }
+                        .font(.system(size: 14, weight: .semibold, design: .rounded))
+                    }
+                    .frame(width: 130)
+                    .padding(.vertical, 6)
+                    .glassEffect(.regular, in: .capsule)
+                    .frame(maxWidth: .infinity)
+                    .padding(.bottom, 4)
+                    .contentShape(Rectangle())
+                    .contentTransition(.numericText())
+                    .animation(.smooth, value: index)
                 }
-                Spacer()
-                VStack(spacing: 0) {
-                    Text("TIME")
-                        .font(.system(size: 8))
-                        .foregroundStyle(.secondary)
-                    Text(timerStartDate, style: .timer)
-                        .font(.system(size: 12, weight: .semibold, design: .rounded))
-                }
-                Spacer()
-                VStack(spacing: 0) {
-                    Text("NEXT")
-                        .font(.system(size: 8))
-                        .foregroundStyle(.secondary)
-                    Text(distanceToNext?.formattedDistance ?? "--")
-                        .font(.system(size: 12, weight: .semibold, design: .rounded))
-                        .foregroundStyle(.orange)
-                }
-            }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 6)
-            .background(.black)
         }
     }
 }

--- a/WalkableWatch/Views/WatchMapView.swift
+++ b/WalkableWatch/Views/WatchMapView.swift
@@ -14,6 +14,7 @@ struct WatchMapView: View {
     let elapsedTime: TimeInterval
     let distanceToNext: Double?
     @Binding var cameraPosition: MapCameraPosition
+    var onManualMapInteraction: () -> Void = {}
     @Environment(\.isLuminanceReduced) private var isAOD
 
     var body: some View {
@@ -56,6 +57,9 @@ struct WatchMapView: View {
                 }
             }
             .mapStyle(.standard(elevation: .flat, pointsOfInterest: .excludingAll))
+            .onMapCameraChange { _ in
+                onManualMapInteraction()
+            }
             .onChange(of: isAOD) {
                 // Re-center map when wrist comes back up or goes down
                 if let loc = currentLocation {

--- a/scripts/simulate-walk.sh
+++ b/scripts/simulate-walk.sh
@@ -31,7 +31,7 @@ WAYPOINTS=$(python3 -c "
 import xml.etree.ElementTree as ET
 tree = ET.parse('$GPX_FILE')
 root = tree.getroot()
-tags = ['wpt', 'trkpt', 'rtept']
+tags = ['trkpt', 'wpt', 'rtept']
 ns_options = [{}, {'': 'http://www.topografix.com/GPX/1/1'}]
 pts = []
 for ns in ns_options:


### PR DESCRIPTION
## Summary
- Glass rotating stats pill on Watch map view with proper hitbox for tab swiping
- AOD timer shows -:-- instead of frozen stale time
- Map auto-re-centers after idle, on AOD toggle, and on tab switch
- Waypoint arrival banner with fade animation + double haptic
- HealthKit workout import as sync fallback (reads Walkable workouts from Health)
- Session sync via sendMessage + transferUserInfo + applicationContext
- GPS sim script prioritizes trkpt over rtept

## Test plan
- [ ] Start walk on Watch, verify glass pill rotates distance/time/next
- [ ] Swipe near pill to switch tabs
- [ ] Lower wrist, verify AOD shows -:-- and switches to tab 0
- [ ] Reach waypoint, verify banner fades in/out with haptics
- [ ] End walk, open iPhone app, verify session imports from HealthKit